### PR TITLE
feat: complete Discord, Cron, Webhook, and HTTP /chat stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "futures",
  "garudust-agent",
  "garudust-core",

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use clap::Parser;
-use garudust_agent::Agent;
+use garudust_agent::{Agent, AutoApprover};
 use garudust_core::{config::AgentConfig, platform::PlatformAdapter};
+use garudust_cron::CronScheduler;
 use garudust_gateway::{create_router, AppState, GatewayHandler, SessionRegistry};
 use garudust_memory::{FileMemoryStore, SessionDb};
-use garudust_platforms::{discord::DiscordAdapter, telegram::TelegramAdapter};
+use garudust_platforms::{
+    discord::DiscordAdapter, telegram::TelegramAdapter, webhook::WebhookAdapter,
+};
 use garudust_tools::{
     toolsets::{
         files::{ReadFile, WriteFile},
@@ -25,15 +28,18 @@ struct Cli {
     #[arg(long, env = "GARUDUST_PORT", default_value = "3000")]
     port: u16,
 
-    /// Override model (env: GARUDUST_MODEL)
+    /// Port for the webhook adapter (0 = disabled)
+    #[arg(long, env = "GARUDUST_WEBHOOK_PORT", default_value = "3001")]
+    webhook_port: u16,
+
+    /// Override model
     #[arg(long, env = "GARUDUST_MODEL")]
     model: Option<String>,
 
-    /// Override OpenRouter API key (env: OPENROUTER_API_KEY)
     #[arg(long, env = "OPENROUTER_API_KEY")]
     api_key: Option<String>,
 
-    /// Override Anthropic API key — sets provider=anthropic (env: ANTHROPIC_API_KEY)
+    /// Sets provider=anthropic when provided
     #[arg(long, env = "ANTHROPIC_API_KEY")]
     anthropic_key: Option<String>,
 
@@ -42,6 +48,11 @@ struct Cli {
 
     #[arg(long, env = "DISCORD_TOKEN")]
     discord_token: Option<String>,
+
+    /// Comma-separated list of cron jobs: "cron_expr=task" pairs
+    /// e.g. "0 9 * * *=Good morning report"
+    #[arg(long, env = "GARUDUST_CRON_JOBS")]
+    cron_jobs: Option<String>,
 }
 
 fn build_config(cli: &Cli) -> Arc<AgentConfig> {
@@ -95,13 +106,12 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let cli = Cli::parse();
-
     let config = build_config(&cli);
     let db = Arc::new(SessionDb::open(&config.home_dir)?);
     let agent = build_agent(config.clone(), db.clone());
     let sessions = SessionRegistry::new();
 
-    // ── Platform adapters ────────────────────────────────────────────────────
+    // ── Platform adapters ─────────────────────────────────────────────────────
     if let Some(token) = &cli.telegram_token {
         let platform: Arc<dyn PlatformAdapter> = Arc::new(TelegramAdapter::new(token.clone()));
         start_platform(platform, agent.clone(), sessions.clone()).await?;
@@ -112,10 +122,30 @@ async fn main() -> Result<()> {
         start_platform(platform, agent.clone(), sessions.clone()).await?;
     }
 
-    // ── HTTP gateway ─────────────────────────────────────────────────────────
+    if cli.webhook_port > 0 {
+        let platform: Arc<dyn PlatformAdapter> = Arc::new(WebhookAdapter::new(cli.webhook_port));
+        start_platform(platform, agent.clone(), sessions.clone()).await?;
+    }
+
+    // ── Cron scheduler ────────────────────────────────────────────────────────
+    if let Some(jobs_str) = &cli.cron_jobs {
+        let scheduler = CronScheduler::new(agent.clone(), Arc::new(AutoApprover)).await?;
+        for entry in jobs_str.split(',') {
+            if let Some((expr, task)) = entry.trim().split_once('=') {
+                scheduler
+                    .add_job(expr.trim(), task.trim().to_string())
+                    .await?;
+                tracing::info!(cron = %expr.trim(), task = %task.trim(), "cron job registered");
+            }
+        }
+        scheduler.start().await?;
+    }
+
+    // ── HTTP gateway ──────────────────────────────────────────────────────────
     let state = AppState {
         config,
         session_db: db,
+        agent,
     };
     let router = create_router(state);
     let addr = format!("0.0.0.0:{}", cli.port);

--- a/crates/garudust-cron/src/scheduler.rs
+++ b/crates/garudust-cron/src/scheduler.rs
@@ -1,22 +1,44 @@
+use std::sync::Arc;
+
+use garudust_agent::Agent;
+use garudust_core::tool::CommandApprover;
 use tokio_cron_scheduler::{Job, JobScheduler};
 
 pub struct CronScheduler {
     inner: JobScheduler,
+    agent: Arc<Agent>,
+    approver: Arc<dyn CommandApprover>,
 }
 
 impl CronScheduler {
-    pub async fn new() -> anyhow::Result<Self> {
+    pub async fn new(
+        agent: Arc<Agent>,
+        approver: Arc<dyn CommandApprover>,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             inner: JobScheduler::new().await?,
+            agent,
+            approver,
         })
     }
 
     pub async fn add_job(&self, cron_expr: &str, task: String) -> anyhow::Result<()> {
+        let agent = self.agent.clone();
+        let approver = self.approver.clone();
         let job = Job::new_async(cron_expr, move |_uuid, _lock| {
+            let agent = agent.clone();
+            let approver = approver.clone();
             let task = task.clone();
             Box::pin(async move {
-                tracing::info!("Running cron job: {}", task);
-                // TODO: spawn agent with task
+                tracing::info!(task = %task, "cron job starting");
+                match agent.run(&task, approver, "cron").await {
+                    Ok(result) => tracing::info!(
+                        task = %task,
+                        iterations = result.iterations,
+                        "cron job completed"
+                    ),
+                    Err(e) => tracing::error!(task = %task, error = %e, "cron job failed"),
+                }
             })
         })?;
         self.inner.add(job).await?;

--- a/crates/garudust-gateway/src/handler.rs
+++ b/crates/garudust-gateway/src/handler.rs
@@ -13,7 +13,6 @@ use crate::sessions::SessionRegistry;
 pub struct GatewayHandler {
     agent: Arc<Agent>,
     platform: Arc<dyn PlatformAdapter>,
-    #[allow(dead_code)]
     sessions: Arc<SessionRegistry>,
     approver: Arc<AutoApprover>,
 }
@@ -36,15 +35,19 @@ impl GatewayHandler {
 #[async_trait]
 impl MessageHandler for GatewayHandler {
     async fn handle(&self, msg: InboundMessage) -> Result<(), anyhow::Error> {
-        let platform_name = self.platform.name().to_string();
-        let channel = msg.channel.clone();
+        // Track session activity
+        self.sessions
+            .touch(&msg.session_key, &msg.channel.platform, &msg.user_id)
+            .await;
 
-        // Spawn in background so we don't block the platform receive loop
+        let channel = msg.channel.clone();
         let agent = self.agent.clone();
         let platform = self.platform.clone();
         let approver = self.approver.clone();
         let task = msg.text.clone();
+        let platform_name = msg.channel.platform.clone();
 
+        // Spawn in background so we don't block the platform receive loop
         tokio::spawn(async move {
             match agent.run(&task, approver, &platform_name).await {
                 Ok(result) => {

--- a/crates/garudust-gateway/src/router.rs
+++ b/crates/garudust-gateway/src/router.rs
@@ -1,4 +1,13 @@
-use axum::{routing::get, Router};
+use std::sync::Arc;
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use garudust_agent::AutoApprover;
+use serde::{Deserialize, Serialize};
 
 use crate::state::AppState;
 
@@ -6,8 +15,44 @@ async fn health() -> &'static str {
     "ok"
 }
 
+#[derive(Deserialize)]
+struct ChatRequest {
+    message: String,
+}
+
+#[derive(Serialize)]
+struct ChatResponse {
+    output: String,
+    session_id: String,
+    iterations: u32,
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+async fn chat(
+    State(state): State<AppState>,
+    Json(req): Json<ChatRequest>,
+) -> Result<Json<ChatResponse>, (StatusCode, String)> {
+    let approver = Arc::new(AutoApprover);
+    state
+        .agent
+        .run(&req.message, approver, "http")
+        .await
+        .map(|r| {
+            Json(ChatResponse {
+                output: r.output,
+                session_id: r.session_id,
+                iterations: r.iterations,
+                input_tokens: r.usage.input_tokens,
+                output_tokens: r.usage.output_tokens,
+            })
+        })
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
 pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
+        .route("/chat", post(chat))
         .with_state(state)
 }

--- a/crates/garudust-gateway/src/state.rs
+++ b/crates/garudust-gateway/src/state.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use garudust_agent::Agent;
 use garudust_core::config::AgentConfig;
 use garudust_memory::SessionDb;
 
@@ -7,4 +8,5 @@ use garudust_memory::SessionDb;
 pub struct AppState {
     pub config: Arc<AgentConfig>,
     pub session_db: Arc<SessionDb>,
+    pub agent: Arc<Agent>,
 }

--- a/crates/garudust-platforms/Cargo.toml
+++ b/crates/garudust-platforms/Cargo.toml
@@ -4,10 +4,11 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [features]
-default  = ["telegram"]
+default  = ["telegram", "webhook"]
 telegram = ["dep:teloxide"]
 discord  = ["dep:serenity"]
-all      = ["telegram", "discord"]
+webhook  = ["dep:axum"]
+all      = ["telegram", "discord", "webhook"]
 
 [dependencies]
 garudust-core  = { path = "../garudust-core" }
@@ -21,5 +22,6 @@ anyhow         = { workspace = true }
 thiserror      = { workspace = true }
 futures        = { workspace = true }
 reqwest        = { workspace = true }
+axum           = { workspace = true, optional = true }
 teloxide       = { workspace = true, optional = true }
 serenity       = { workspace = true, optional = true }

--- a/crates/garudust-platforms/src/discord.rs
+++ b/crates/garudust-platforms/src/discord.rs
@@ -13,9 +13,11 @@ use serenity::{
     model::{channel::Message, gateway::Ready},
     prelude::*,
 };
+use tokio::sync::Mutex;
 
 struct DiscordHandler {
     handler: Arc<dyn MessageHandler>,
+    ctx_store: Arc<Mutex<Option<Context>>>,
 }
 
 #[serenity_async_trait]
@@ -39,18 +41,23 @@ impl EventHandler for DiscordHandler {
         let _ = self.handler.handle(inbound).await;
     }
 
-    async fn ready(&self, _ctx: Context, ready: Ready) {
+    async fn ready(&self, ctx: Context, ready: Ready) {
+        *self.ctx_store.lock().await = Some(ctx);
         tracing::info!("Discord bot connected as {}", ready.user.name);
     }
 }
 
 pub struct DiscordAdapter {
     token: String,
+    ctx_store: Arc<Mutex<Option<Context>>>,
 }
 
 impl DiscordAdapter {
     pub fn new(token: String) -> Self {
-        Self { token }
+        Self {
+            token,
+            ctx_store: Arc::new(Mutex::new(None)),
+        }
     }
 }
 
@@ -62,12 +69,13 @@ impl PlatformAdapter for DiscordAdapter {
 
     async fn start(&self, handler: Arc<dyn MessageHandler>) -> Result<(), PlatformError> {
         let token = self.token.clone();
+        let ctx_store = self.ctx_store.clone();
         tokio::spawn(async move {
             let intents = GatewayIntents::GUILD_MESSAGES
                 | GatewayIntents::DIRECT_MESSAGES
                 | GatewayIntents::MESSAGE_CONTENT;
             let mut client = Client::builder(&token, intents)
-                .event_handler(DiscordHandler { handler })
+                .event_handler(DiscordHandler { handler, ctx_store })
                 .await
                 .expect("Discord client failed");
             client.start().await.expect("Discord start failed");
@@ -77,20 +85,36 @@ impl PlatformAdapter for DiscordAdapter {
 
     async fn send_message(
         &self,
-        _channel: &ChannelId,
-        _message: OutboundMessage,
+        channel: &ChannelId,
+        message: OutboundMessage,
     ) -> Result<(), PlatformError> {
-        // Sending requires ctx from serenity — wired up properly in Phase 6
-        Err(PlatformError::Send("send not yet implemented".into()))
+        let guard = self.ctx_store.lock().await;
+        let ctx = guard
+            .as_ref()
+            .ok_or_else(|| PlatformError::Send("Discord not connected yet".into()))?;
+
+        let channel_id: u64 = channel
+            .chat_id
+            .parse()
+            .map_err(|_| PlatformError::Send("invalid channel_id".into()))?;
+
+        serenity::model::id::ChannelId::new(channel_id)
+            .say(&ctx.http, &message.text)
+            .await
+            .map_err(|e| PlatformError::Send(e.to_string()))?;
+        Ok(())
     }
 
     async fn send_stream(
         &self,
-        _channel: &ChannelId,
-        _stream: Pin<Box<dyn Stream<Item = String> + Send>>,
+        channel: &ChannelId,
+        mut stream: Pin<Box<dyn Stream<Item = String> + Send>>,
     ) -> Result<(), PlatformError> {
-        Err(PlatformError::Send(
-            "stream send not yet implemented".into(),
-        ))
+        use futures::StreamExt;
+        let mut buf = String::new();
+        while let Some(chunk) = stream.next().await {
+            buf.push_str(&chunk);
+        }
+        self.send_message(channel, OutboundMessage::text(buf)).await
     }
 }

--- a/crates/garudust-platforms/src/lib.rs
+++ b/crates/garudust-platforms/src/lib.rs
@@ -4,4 +4,5 @@ pub mod telegram;
 #[cfg(feature = "discord")]
 pub mod discord;
 
+#[cfg(feature = "webhook")]
 pub mod webhook;

--- a/crates/garudust-platforms/src/webhook.rs
+++ b/crates/garudust-platforms/src/webhook.rs
@@ -2,15 +2,71 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use axum::{extract::State, routing::post, Json, Router};
 use futures::Stream;
 use garudust_core::{
     error::PlatformError,
     platform::{MessageHandler, PlatformAdapter},
-    types::{ChannelId, OutboundMessage},
+    types::{ChannelId, InboundMessage, OutboundMessage},
 };
+use serde::{Deserialize, Serialize};
 
-/// Minimal webhook adapter — receives POST requests and sends responses via HTTP callback.
-pub struct WebhookAdapter;
+#[derive(Deserialize)]
+struct WebhookPayload {
+    text: String,
+    /// URL to POST the response back to.
+    callback_url: String,
+    #[serde(default)]
+    user_id: String,
+    #[serde(default)]
+    user_name: String,
+    #[serde(default)]
+    session_key: String,
+}
+
+#[derive(Serialize)]
+struct CallbackPayload {
+    text: String,
+}
+
+async fn handle_webhook(
+    State(handler): State<Arc<dyn MessageHandler>>,
+    Json(payload): Json<WebhookPayload>,
+) -> axum::http::StatusCode {
+    let session_key = if payload.session_key.is_empty() {
+        format!("webhook:{}", payload.callback_url)
+    } else {
+        payload.session_key.clone()
+    };
+
+    let inbound = InboundMessage {
+        channel: ChannelId {
+            platform: "webhook".into(),
+            // chat_id holds the callback URL so send_message can POST back
+            chat_id: payload.callback_url,
+            thread_id: None,
+        },
+        user_id: payload.user_id,
+        user_name: payload.user_name,
+        text: payload.text,
+        session_key,
+    };
+
+    match handler.handle(inbound).await {
+        Ok(()) => axum::http::StatusCode::ACCEPTED,
+        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+pub struct WebhookAdapter {
+    port: u16,
+}
+
+impl WebhookAdapter {
+    pub fn new(port: u16) -> Self {
+        Self { port }
+    }
+}
 
 #[async_trait]
 impl PlatformAdapter for WebhookAdapter {
@@ -18,25 +74,50 @@ impl PlatformAdapter for WebhookAdapter {
         "webhook"
     }
 
-    async fn start(&self, _handler: Arc<dyn MessageHandler>) -> Result<(), PlatformError> {
-        // TODO: start axum listener
+    async fn start(&self, handler: Arc<dyn MessageHandler>) -> Result<(), PlatformError> {
+        let port = self.port;
+        let router = Router::new()
+            .route("/webhook", post(handle_webhook))
+            .with_state(handler);
+
+        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+            .await
+            .map_err(|e| PlatformError::Connection(e.to_string()))?;
+
+        tracing::info!("webhook adapter listening on 0.0.0.0:{port}");
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, router).await {
+                tracing::error!("webhook server error: {e}");
+            }
+        });
         Ok(())
     }
 
     async fn send_message(
         &self,
-        _channel: &ChannelId,
-        _message: OutboundMessage,
+        channel: &ChannelId,
+        message: OutboundMessage,
     ) -> Result<(), PlatformError> {
-        // TODO: HTTP POST to callback URL
+        let client = reqwest::Client::new();
+        client
+            .post(&channel.chat_id)
+            .json(&CallbackPayload { text: message.text })
+            .send()
+            .await
+            .map_err(|e| PlatformError::Send(e.to_string()))?;
         Ok(())
     }
 
     async fn send_stream(
         &self,
-        _channel: &ChannelId,
-        _stream: Pin<Box<dyn Stream<Item = String> + Send>>,
+        channel: &ChannelId,
+        mut stream: Pin<Box<dyn Stream<Item = String> + Send>>,
     ) -> Result<(), PlatformError> {
-        Ok(())
+        use futures::StreamExt;
+        let mut buf = String::new();
+        while let Some(chunk) = stream.next().await {
+            buf.push_str(&chunk);
+        }
+        self.send_message(channel, OutboundMessage::text(buf)).await
     }
 }


### PR DESCRIPTION
## Summary

- **Discord \`send_message\`** — ตอบกลับข้อความได้แล้ว โดย store serenity \`Context\` ใน \`Arc<Mutex<Option<Context>>>\` ที่ share ระหว่าง \`EventHandler::ready\` และ \`PlatformAdapter::send_message\`
- **Cron scheduler** — \`CronScheduler::new(agent, approver)\` รับ \`Arc<Agent>\` แล้วเรียก \`agent.run()\` จริงใน job closure; server รับ \`GARUDUST_CRON_JOBS="0 9 * * *=Daily report,..."\` env var
- **Webhook platform** — \`WebhookAdapter::new(port)\` bind axum listener บน \`POST /webhook\`; \`send_message\` HTTP POST กลับไปที่ \`callback_url\` ใน payload
- **HTTP \`/chat\` endpoint** — \`POST /chat {"message":"..."}\` → \`{output, session_id, iterations, input_tokens, output_tokens}\`; เพิ่ม \`agent: Arc<Agent>\` ใน \`AppState\`
- **SessionRegistry** — \`GatewayHandler\` เรียก \`sessions.touch()\` ทุกครั้งที่รับข้อความ

## What was a stub before → now works

| Component | Before | After |
|-----------|--------|-------|
| Discord \`send_message\` | \`Err("not yet implemented")\` | ✅ ส่งผ่าน serenity \`ChannelId::say()\` |
| Cron \`add_job\` | log only + \`// TODO\` | ✅ spawn \`agent.run()\` |
| Webhook \`start()\` | no-op | ✅ axum listener |
| Webhook \`send_message\` | no-op | ✅ HTTP POST callback |
| HTTP \`/health\` only | \`/health\` | ✅ \`/health\` + \`/chat\` |
| \`SessionRegistry\` | created, never used | ✅ \`touch()\` on every message |

## Test plan

- [x] \`POST /chat\` → endpoint exists, routes correctly, returns \`transport error: authentication failed\` (not 404) when no API key — full JSON response verified with valid key
- [x] \`POST /webhook\` → returns \`202 Accepted\`; webhook adapter starts and binds port on server startup
- [ ] Telegram bot ตอบกลับข้อความ — ต้องการ \`TELEGRAM_TOKEN\` จริง
- [ ] Discord bot ตอบกลับข้อความ — ต้องการ \`DISCORD_TOKEN\` จริง
- [ ] \`GARUDUST_CRON_JOBS="* * * * *=say hello"\` → เห็น log "cron job completed" ทุก 1 นาที — ต้องการ API key จริง
- [x] \`cargo check --workspace\` ผ่าน — CI ✅ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)