### PR TITLE
feat: streaming, slash commands, MCP client, session_search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1116,7 @@ dependencies = [
  "garudust-core",
  "garudust-memory",
  "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1101,6 +1130,7 @@ name = "garudust-transport"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "futures",
  "garudust-core",
@@ -1870,6 +1900,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,6 +2038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2146,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -2297,6 +2359,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2498,43 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2573,6 +2692,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,6 +2799,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3889,6 +4045,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +4076,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3928,6 +4116,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4049,6 +4247,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,4 @@ teloxide  = { version = "0.13", features = ["macros"] }
 serenity  = { version = "0.12", features = ["client", "gateway", "model"] }
 
 # MCP
-rmcp = { version = "0.1", features = ["client"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use clap::Parser;
 use garudust_agent::{Agent, AutoApprover};
+use garudust_core::config::McpServerConfig;
 use garudust_core::{config::AgentConfig, platform::PlatformAdapter};
 use garudust_cron::CronScheduler;
 use garudust_gateway::{create_router, AppState, GatewayHandler, SessionRegistry};
@@ -10,7 +11,6 @@ use garudust_memory::{FileMemoryStore, SessionDb};
 use garudust_platforms::{
     discord::DiscordAdapter, telegram::TelegramAdapter, webhook::WebhookAdapter,
 };
-use garudust_core::config::McpServerConfig;
 use garudust_tools::{
     toolsets::{
         files::{ReadFile, WriteFile},

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -10,10 +10,13 @@ use garudust_memory::{FileMemoryStore, SessionDb};
 use garudust_platforms::{
     discord::DiscordAdapter, telegram::TelegramAdapter, webhook::WebhookAdapter,
 };
+use garudust_core::config::McpServerConfig;
 use garudust_tools::{
     toolsets::{
         files::{ReadFile, WriteFile},
+        mcp::connect_mcp_server,
         memory::MemoryTool,
+        search::SessionSearch,
         skills::{SkillView, SkillsList},
         terminal::Terminal,
         web::{WebFetch, WebSearch},
@@ -69,7 +72,7 @@ fn build_config(cli: &Cli) -> Arc<AgentConfig> {
     Arc::new(config)
 }
 
-fn build_agent(config: Arc<AgentConfig>, db: Arc<SessionDb>) -> Arc<Agent> {
+async fn build_agent(config: Arc<AgentConfig>, db: Arc<SessionDb>) -> Arc<Agent> {
     let memory = Arc::new(FileMemoryStore::new(&config.home_dir));
     let transport = build_transport(&config);
 
@@ -80,10 +83,36 @@ fn build_agent(config: Arc<AgentConfig>, db: Arc<SessionDb>) -> Arc<Agent> {
     registry.register(WriteFile);
     registry.register(Terminal);
     registry.register(MemoryTool);
+    registry.register(SessionSearch);
     registry.register(SkillsList);
     registry.register(SkillView);
 
+    let _mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
+    std::mem::forget(_mcp_handles);
+
     Arc::new(Agent::new(transport, Arc::new(registry), memory, config).with_session_db(db))
+}
+
+async fn attach_mcp_servers(
+    registry: &mut ToolRegistry,
+    servers: &[McpServerConfig],
+) -> Vec<Box<dyn std::any::Any + Send>> {
+    let mut handles: Vec<Box<dyn std::any::Any + Send>> = Vec::new();
+    for srv in servers {
+        match connect_mcp_server(&srv.command, &srv.args).await {
+            Ok((tools, handle)) => {
+                tracing::info!(server = %srv.name, tools = tools.len(), "MCP server connected");
+                for t in tools {
+                    registry.register_arc(t);
+                }
+                handles.push(handle);
+            }
+            Err(e) => {
+                tracing::warn!(server = %srv.name, "failed to connect MCP server: {e}");
+            }
+        }
+    }
+    handles
 }
 
 async fn start_platform(
@@ -108,7 +137,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let config = build_config(&cli);
     let db = Arc::new(SessionDb::open(&config.home_dir)?);
-    let agent = build_agent(config.clone(), db.clone());
+    let agent = build_agent(config.clone(), db.clone()).await;
     let sessions = SessionRegistry::new();
 
     // ── Platform adapters ─────────────────────────────────────────────────────

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -87,8 +87,8 @@ async fn build_agent(config: Arc<AgentConfig>, db: Arc<SessionDb>) -> Arc<Agent>
     registry.register(SkillsList);
     registry.register(SkillView);
 
-    let _mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
-    std::mem::forget(_mcp_handles);
+    let mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
+    std::mem::forget(mcp_handles);
 
     Arc::new(Agent::new(transport, Arc::new(registry), memory, config).with_session_db(db))
 }

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -10,10 +10,13 @@ use clap::{Parser, Subcommand};
 use garudust_agent::{Agent, AutoApprover};
 use garudust_core::config::AgentConfig;
 use garudust_memory::{FileMemoryStore, SessionDb};
+use garudust_core::config::McpServerConfig;
 use garudust_tools::{
     toolsets::{
         files::{ReadFile, WriteFile},
+        mcp::connect_mcp_server,
         memory::MemoryTool,
+        search::SessionSearch,
         skills::{SkillView, SkillsList},
         terminal::Terminal,
         web::{WebFetch, WebSearch},
@@ -24,6 +27,7 @@ use garudust_transport::build_transport;
 use tokio::sync::mpsc;
 
 use tui::{AgentEvent, TuiEvent};
+use tokio::sync::RwLock;
 
 #[derive(Subcommand)]
 enum ConfigCmd {
@@ -108,6 +112,7 @@ fn build_agent(config: Arc<AgentConfig>) -> Arc<Agent> {
     registry.register(WriteFile);
     registry.register(Terminal);
     registry.register(MemoryTool);
+    registry.register(SessionSearch);
     registry.register(SkillsList);
     registry.register(SkillView);
 
@@ -118,6 +123,28 @@ fn build_agent(config: Arc<AgentConfig>) -> Arc<Agent> {
         None => agent,
     };
     Arc::new(agent)
+}
+
+async fn attach_mcp_servers(
+    registry: &mut ToolRegistry,
+    servers: &[McpServerConfig],
+) -> Vec<Box<dyn std::any::Any + Send>> {
+    let mut handles: Vec<Box<dyn std::any::Any + Send>> = Vec::new();
+    for srv in servers {
+        match connect_mcp_server(&srv.command, &srv.args).await {
+            Ok((tools, handle)) => {
+                tracing::info!(server = %srv.name, tools = tools.len(), "MCP server connected");
+                for t in tools {
+                    registry.register_arc(t);
+                }
+                handles.push(handle);
+            }
+            Err(e) => {
+                tracing::warn!(server = %srv.name, "failed to connect MCP server: {e}");
+            }
+        }
+    }
+    handles
 }
 
 #[tokio::main]
@@ -162,7 +189,27 @@ async fn main() -> Result<()> {
 
     // ── Agent modes ───────────────────────────────────────────────────────────
     let config = build_config(&cli);
-    let agent = build_agent(config);
+    let agent = {
+        let memory = Arc::new(FileMemoryStore::new(&config.home_dir));
+        let transport = build_transport(&config);
+        let mut registry = ToolRegistry::new();
+        registry.register(WebFetch);
+        registry.register(WebSearch);
+        registry.register(ReadFile);
+        registry.register(WriteFile);
+        registry.register(Terminal);
+        registry.register(MemoryTool);
+        registry.register(SessionSearch);
+        registry.register(SkillsList);
+        registry.register(SkillView);
+        let _mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
+        let db = SessionDb::open(&config.home_dir).ok().map(Arc::new);
+        let a = Agent::new(transport, Arc::new(registry), memory, config.clone());
+        let a = match db { Some(db) => a.with_session_db(db), None => a };
+        // leak _mcp_handles so the MCP processes stay alive for the entire run
+        std::mem::forget(_mcp_handles);
+        Arc::new(a)
+    };
 
     if let Some(task) = &cli.task {
         // One-shot mode
@@ -180,18 +227,39 @@ async fn main() -> Result<()> {
         let (tx_event, mut rx_event) = mpsc::channel::<TuiEvent>(32);
         let (tx_agent, rx_agent) = mpsc::channel::<AgentEvent>(64);
 
-        let agent2 = agent.clone();
+        let shared_agent = Arc::new(RwLock::new(agent.clone()));
+        let shared_config = config.clone();
         let approver2 = approver.clone();
         let tx_agent2 = tx_agent.clone();
+
         tokio::spawn(async move {
             while let Some(ev) = rx_event.recv().await {
                 match ev {
                     TuiEvent::Quit => break,
+                    TuiEvent::NewSession => {} // agent is stateless per-call; UI already cleared
+                    TuiEvent::ChangeModel(model) => {
+                        let mut new_cfg = (*shared_config).clone();
+                        new_cfg.model = model;
+                        let new_agent = build_agent(Arc::new(new_cfg));
+                        *shared_agent.write().await = new_agent;
+                    }
                     TuiEvent::Submit(task) => {
                         let _ = tx_agent2.send(AgentEvent::Thinking).await;
-                        match agent2.run(&task, approver2.clone(), "cli").await {
+                        let current_agent = shared_agent.read().await.clone();
+
+                        let (chunk_tx, mut chunk_rx) = mpsc::unbounded_channel::<String>();
+                        let tx_agent3 = tx_agent2.clone();
+                        tokio::spawn(async move {
+                            while let Some(delta) = chunk_rx.recv().await {
+                                let _ = tx_agent3.send(AgentEvent::OutputChunk(delta)).await;
+                            }
+                        });
+
+                        match current_agent
+                            .run_streaming(&task, approver2.clone(), "cli", chunk_tx)
+                            .await
+                        {
                             Ok(r) => {
-                                let _ = tx_agent2.send(AgentEvent::Output(r.output)).await;
                                 let _ = tx_agent2
                                     .send(AgentEvent::Done {
                                         iterations: r.iterations,

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -202,15 +202,15 @@ async fn main() -> Result<()> {
         registry.register(SessionSearch);
         registry.register(SkillsList);
         registry.register(SkillView);
-        let _mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
+        let mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
         let db = SessionDb::open(&config.home_dir).ok().map(Arc::new);
         let a = Agent::new(transport, Arc::new(registry), memory, config.clone());
         let a = match db {
             Some(db) => a.with_session_db(db),
             None => a,
         };
-        // leak _mcp_handles so the MCP processes stay alive for the entire run
-        std::mem::forget(_mcp_handles);
+        // leak mcp_handles so the MCP processes stay alive for the entire run
+        std::mem::forget(mcp_handles);
         Arc::new(a)
     };
 

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use garudust_agent::{Agent, AutoApprover};
 use garudust_core::config::AgentConfig;
-use garudust_memory::{FileMemoryStore, SessionDb};
 use garudust_core::config::McpServerConfig;
+use garudust_memory::{FileMemoryStore, SessionDb};
 use garudust_tools::{
     toolsets::{
         files::{ReadFile, WriteFile},
@@ -26,8 +26,8 @@ use garudust_tools::{
 use garudust_transport::build_transport;
 use tokio::sync::mpsc;
 
-use tui::{AgentEvent, TuiEvent};
 use tokio::sync::RwLock;
+use tui::{AgentEvent, TuiEvent};
 
 #[derive(Subcommand)]
 enum ConfigCmd {
@@ -205,7 +205,10 @@ async fn main() -> Result<()> {
         let _mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
         let db = SessionDb::open(&config.home_dir).ok().map(Arc::new);
         let a = Agent::new(transport, Arc::new(registry), memory, config.clone());
-        let a = match db { Some(db) => a.with_session_db(db), None => a };
+        let a = match db {
+            Some(db) => a.with_session_db(db),
+            None => a,
+        };
         // leak _mcp_handles so the MCP processes stay alive for the entire run
         std::mem::forget(_mcp_handles);
         Arc::new(a)

--- a/bin/garudust/src/tui.rs
+++ b/bin/garudust/src/tui.rs
@@ -107,24 +107,43 @@ impl Tui {
                                     match cmd {
                                         "new" => {
                                             tui.messages.clear();
-                                            tui.messages.push((Role::Assistant, "New session started.".into()));
+                                            tui.messages.push((
+                                                Role::Assistant,
+                                                "New session started.".into(),
+                                            ));
                                             let _ = tx_event.send(TuiEvent::NewSession).await;
                                         }
                                         "model" => match args {
                                             Some(m) if !m.is_empty() => {
-                                                tui.messages.push((Role::Assistant, format!("Model → {m}")));
-                                                let _ = tx_event.send(TuiEvent::ChangeModel(m.to_string())).await;
+                                                tui.messages.push((
+                                                    Role::Assistant,
+                                                    format!("Model → {m}"),
+                                                ));
+                                                let _ = tx_event
+                                                    .send(TuiEvent::ChangeModel(m.to_string()))
+                                                    .await;
                                             }
-                                            _ => tui.messages.push((Role::Error, "Usage: /model <model-name>".into())),
+                                            _ => tui.messages.push((
+                                                Role::Error,
+                                                "Usage: /model <model-name>".into(),
+                                            )),
                                         },
                                         "help" => {
-                                            tui.messages.push((Role::Assistant,
+                                            tui.messages.push((
+                                                Role::Assistant,
                                                 "/new       — clear history and start fresh\n\
                                                  /model <n> — switch to a different model\n\
-                                                 /help      — show this help".into()));
+                                                 /help      — show this help"
+                                                    .into(),
+                                            ));
                                         }
                                         _ => {
-                                            tui.messages.push((Role::Error, format!("Unknown command /{cmd}. Type /help for help.")));
+                                            tui.messages.push((
+                                                Role::Error,
+                                                format!(
+                                                    "Unknown command /{cmd}. Type /help for help."
+                                                ),
+                                            ));
                                         }
                                     }
                                 } else {

--- a/bin/garudust/src/tui.rs
+++ b/bin/garudust/src/tui.rs
@@ -102,8 +102,7 @@ impl Tui {
                                 if let Some(rest) = text.strip_prefix('/') {
                                     let (cmd, args) = rest
                                         .split_once(' ')
-                                        .map(|(c, a)| (c, Some(a.trim())))
-                                        .unwrap_or((rest, None));
+                                        .map_or((rest, None), |(c, a)| (c, Some(a.trim())));
                                     match cmd {
                                         "new" => {
                                             tui.messages.clear();

--- a/bin/garudust/src/tui.rs
+++ b/bin/garudust/src/tui.rs
@@ -15,15 +15,11 @@ use ratatui::{
 };
 use tokio::sync::mpsc;
 
-#[derive(Debug)]
-pub enum TuiEvent {
-    Submit(String),
-    Quit,
-}
-
 #[derive(Debug, Clone)]
 pub enum AgentEvent {
+    #[allow(dead_code)]
     Output(String),
+    OutputChunk(String),
     Thinking,
     Done {
         iterations: u32,
@@ -33,11 +29,20 @@ pub enum AgentEvent {
     Error(String),
 }
 
+#[derive(Debug, Clone)]
+pub enum TuiEvent {
+    Submit(String),
+    Quit,
+    NewSession,
+    ChangeModel(String),
+}
+
 pub struct Tui {
     input: String,
     messages: Vec<(Role, String)>,
     status: String,
     scroll: u16,
+    streaming: bool,
 }
 
 #[derive(Clone)]
@@ -54,6 +59,7 @@ impl Tui {
             messages: Vec::new(),
             status: "Ready — press Enter to send, Ctrl+C to quit".into(),
             scroll: 0,
+            streaming: false,
         }
     }
 
@@ -92,10 +98,40 @@ impl Tui {
                         (KeyCode::Enter, _) => {
                             let text = tui.input.trim().to_string();
                             if !text.is_empty() {
-                                tui.messages.push((Role::User, text.clone()));
-                                tui.status = "Thinking…".into();
                                 tui.input.clear();
-                                let _ = tx_event.send(TuiEvent::Submit(text)).await;
+                                if let Some(rest) = text.strip_prefix('/') {
+                                    let (cmd, args) = rest
+                                        .split_once(' ')
+                                        .map(|(c, a)| (c, Some(a.trim())))
+                                        .unwrap_or((rest, None));
+                                    match cmd {
+                                        "new" => {
+                                            tui.messages.clear();
+                                            tui.messages.push((Role::Assistant, "New session started.".into()));
+                                            let _ = tx_event.send(TuiEvent::NewSession).await;
+                                        }
+                                        "model" => match args {
+                                            Some(m) if !m.is_empty() => {
+                                                tui.messages.push((Role::Assistant, format!("Model → {m}")));
+                                                let _ = tx_event.send(TuiEvent::ChangeModel(m.to_string())).await;
+                                            }
+                                            _ => tui.messages.push((Role::Error, "Usage: /model <model-name>".into())),
+                                        },
+                                        "help" => {
+                                            tui.messages.push((Role::Assistant,
+                                                "/new       — clear history and start fresh\n\
+                                                 /model <n> — switch to a different model\n\
+                                                 /help      — show this help".into()));
+                                        }
+                                        _ => {
+                                            tui.messages.push((Role::Error, format!("Unknown command /{cmd}. Type /help for help.")));
+                                        }
+                                    }
+                                } else {
+                                    tui.messages.push((Role::User, text.clone()));
+                                    tui.status = "Thinking…".into();
+                                    let _ = tx_event.send(TuiEvent::Submit(text)).await;
+                                }
                             }
                         }
                         (KeyCode::Backspace, _) => {
@@ -122,12 +158,24 @@ impl Tui {
     fn handle_agent_event(&mut self, ev: AgentEvent) {
         match ev {
             AgentEvent::Output(text) => {
+                self.streaming = false;
                 self.messages.push((Role::Assistant, text));
                 self.status = "Ready".into();
-                // auto-scroll to bottom
+                self.scroll = u16::MAX;
+            }
+            AgentEvent::OutputChunk(delta) => {
+                if self.streaming {
+                    if let Some((Role::Assistant, buf)) = self.messages.last_mut() {
+                        buf.push_str(&delta);
+                    }
+                } else {
+                    self.streaming = true;
+                    self.messages.push((Role::Assistant, delta));
+                }
                 self.scroll = u16::MAX;
             }
             AgentEvent::Thinking => {
+                self.streaming = false;
                 self.status = "Thinking…".into();
             }
             AgentEvent::Done {
@@ -135,11 +183,13 @@ impl Tui {
                 input_tokens,
                 output_tokens,
             } => {
+                self.streaming = false;
                 self.status = format!(
                     "Done — {iterations} iterations | {input_tokens} in / {output_tokens} out tokens"
                 );
             }
             AgentEvent::Error(e) => {
+                self.streaming = false;
                 self.messages.push((Role::Error, format!("Error: {e}")));
                 self.status = "Error — ready for next task".into();
             }

--- a/crates/garudust-agent/src/agent.rs
+++ b/crates/garudust-agent/src/agent.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use chrono::Utc;
+use futures::StreamExt;
 use garudust_core::{
     budget::IterationBudget,
     config::AgentConfig,
@@ -8,15 +9,92 @@ use garudust_core::{
     memory::MemoryStore,
     tool::ToolContext,
     transport::ProviderTransport,
-    types::{AgentResult, ContentPart, InferenceConfig, Message, Role, StopReason, ToolResult},
+    types::{
+        AgentResult, ContentPart, InferenceConfig, Message, Role, StopReason, StreamChunk,
+        TokenUsage, ToolCall, ToolResult, TransportResponse,
+    },
 };
 use garudust_memory::SessionDb;
 use garudust_tools::ToolRegistry;
+use serde_json::Value;
+use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::compressor::ContextCompressor;
 use crate::prompt_builder::build_system_prompt;
+
+async fn stream_turn(
+    transport: &dyn ProviderTransport,
+    history: &[Message],
+    config: &InferenceConfig,
+    schemas: &[garudust_core::types::ToolSchema],
+    chunk_tx: &mpsc::UnboundedSender<String>,
+) -> Result<TransportResponse, AgentError> {
+    let mut stream = transport.chat_stream(history, config, schemas).await?;
+
+    let mut text = String::new();
+    let mut tc_acc: Vec<(String, String, String)> = Vec::new();
+    let mut usage = TokenUsage::default();
+
+    while let Some(result) = stream.next().await {
+        match result? {
+            StreamChunk::TextDelta(delta) => {
+                let _ = chunk_tx.send(delta.clone());
+                text.push_str(&delta);
+            }
+            StreamChunk::ToolCallDelta {
+                index,
+                id,
+                name,
+                args_delta,
+            } => {
+                while tc_acc.len() <= index {
+                    tc_acc.push((String::new(), String::new(), String::new()));
+                }
+                if let Some(v) = id {
+                    tc_acc[index].0 = v;
+                }
+                if let Some(v) = name {
+                    tc_acc[index].1 = v;
+                }
+                tc_acc[index].2.push_str(&args_delta);
+            }
+            StreamChunk::Done { usage: u } => {
+                usage = u;
+            }
+        }
+    }
+
+    let content = if text.is_empty() {
+        vec![]
+    } else {
+        vec![ContentPart::Text(text)]
+    };
+
+    let tool_calls: Vec<ToolCall> = tc_acc
+        .into_iter()
+        .filter(|(id, ..)| !id.is_empty())
+        .map(|(id, name, args)| ToolCall {
+            id,
+            name,
+            arguments: serde_json::from_str(&args).unwrap_or(Value::Null),
+        })
+        .collect();
+
+    let stop_reason = if tool_calls.is_empty() {
+        StopReason::EndTurn
+    } else {
+        StopReason::ToolUse
+    };
+
+    Ok(TransportResponse {
+        content,
+        tool_calls,
+        usage,
+        stop_reason,
+    })
+}
 
 pub struct Agent {
     id: String,
@@ -85,6 +163,26 @@ impl Agent {
         approver: Arc<dyn garudust_core::tool::CommandApprover>,
         platform: &str,
     ) -> Result<AgentResult, AgentError> {
+        self.run_inner(task, approver, platform, None).await
+    }
+
+    pub async fn run_streaming(
+        &self,
+        task: &str,
+        approver: Arc<dyn garudust_core::tool::CommandApprover>,
+        platform: &str,
+        chunk_tx: mpsc::UnboundedSender<String>,
+    ) -> Result<AgentResult, AgentError> {
+        self.run_inner(task, approver, platform, Some(chunk_tx)).await
+    }
+
+    async fn run_inner(
+        &self,
+        task: &str,
+        approver: Arc<dyn garudust_core::tool::CommandApprover>,
+        platform: &str,
+        chunk_tx: Option<mpsc::UnboundedSender<String>>,
+    ) -> Result<AgentResult, AgentError> {
         let session_id = Uuid::new_v4().to_string();
         #[allow(clippy::cast_precision_loss)]
         let started_at = Utc::now().timestamp_millis() as f64 / 1000.0;
@@ -117,7 +215,11 @@ impl Agent {
             iters += 1;
             info!(agent_id = %self.id, iteration = iters, "agent turn");
 
-            let resp = self.transport.chat(&history, &inf_config, &schemas).await?;
+            let resp = if let Some(tx) = &chunk_tx {
+                stream_turn(self.transport.as_ref(), &history, &inf_config, &schemas, tx).await?
+            } else {
+                self.transport.chat(&history, &inf_config, &schemas).await?
+            };
             total_in += resp.usage.input_tokens;
             total_out += resp.usage.output_tokens;
 

--- a/crates/garudust-agent/src/agent.rs
+++ b/crates/garudust-agent/src/agent.rs
@@ -173,7 +173,8 @@ impl Agent {
         platform: &str,
         chunk_tx: mpsc::UnboundedSender<String>,
     ) -> Result<AgentResult, AgentError> {
-        self.run_inner(task, approver, platform, Some(chunk_tx)).await
+        self.run_inner(task, approver, platform, Some(chunk_tx))
+            .await
     }
 
     async fn run_inner(

--- a/crates/garudust-core/src/config.rs
+++ b/crates/garudust-core/src/config.rs
@@ -15,6 +15,16 @@ pub struct AgentConfig {
     pub api_key: Option<String>,
     pub compression: CompressionConfig,
     pub network: NetworkConfig,
+    #[serde(default)]
+    pub mcp_servers: Vec<McpServerConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerConfig {
+    pub name: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
 }
 
 impl Default for AgentConfig {
@@ -29,6 +39,7 @@ impl Default for AgentConfig {
             api_key: None,
             compression: CompressionConfig::default(),
             network: NetworkConfig::default(),
+            mcp_servers: Vec::new(),
         }
     }
 }

--- a/crates/garudust-core/src/tool.rs
+++ b/crates/garudust-core/src/tool.rs
@@ -12,10 +12,10 @@ use crate::{
 
 #[async_trait]
 pub trait Tool: Send + Sync + 'static {
-    fn name(&self) -> &'static str;
-    fn description(&self) -> &'static str;
+    fn name(&self) -> &str;
+    fn description(&self) -> &str;
     fn schema(&self) -> serde_json::Value;
-    fn toolset(&self) -> &'static str;
+    fn toolset(&self) -> &str;
 
     async fn execute(
         &self,

--- a/crates/garudust-core/src/transport.rs
+++ b/crates/garudust-core/src/transport.rs
@@ -33,5 +33,6 @@ pub trait ProviderTransport: Send + Sync + 'static {
         &self,
         messages: &[Message],
         config: &InferenceConfig,
+        tools: &[ToolSchema],
     ) -> Result<StreamResult, TransportError>;
 }

--- a/crates/garudust-memory/src/session_db.rs
+++ b/crates/garudust-memory/src/session_db.rs
@@ -22,6 +22,7 @@ impl SessionDb {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn save_session(
         &self,
         id: &str,

--- a/crates/garudust-tools/Cargo.toml
+++ b/crates/garudust-tools/Cargo.toml
@@ -16,3 +16,4 @@ thiserror       = { workspace = true }
 reqwest         = { workspace = true }
 futures         = { workspace = true }
 serde_yaml      = { workspace = true }
+rmcp            = { workspace = true }

--- a/crates/garudust-tools/src/registry.rs
+++ b/crates/garudust-tools/src/registry.rs
@@ -8,7 +8,7 @@ use garudust_core::{
 };
 
 pub struct ToolRegistry {
-    tools: HashMap<&'static str, Arc<dyn Tool>>,
+    tools: HashMap<String, Arc<dyn Tool>>,
 }
 
 impl ToolRegistry {
@@ -19,7 +19,11 @@ impl ToolRegistry {
     }
 
     pub fn register(&mut self, tool: impl Tool + 'static) {
-        self.tools.insert(tool.name(), Arc::new(tool));
+        self.tools.insert(tool.name().to_string(), Arc::new(tool));
+    }
+
+    pub fn register_arc(&mut self, tool: Arc<dyn Tool>) {
+        self.tools.insert(tool.name().to_string(), tool);
     }
 
     pub fn schemas(&self, toolsets: &[&str]) -> Vec<ToolSchema> {
@@ -48,7 +52,7 @@ impl ToolRegistry {
     }
 
     pub fn names(&self) -> Vec<&str> {
-        self.tools.keys().copied().collect()
+        self.tools.keys().map(String::as_str).collect()
     }
 }
 

--- a/crates/garudust-tools/src/toolsets/mcp.rs
+++ b/crates/garudust-tools/src/toolsets/mcp.rs
@@ -59,7 +59,7 @@ impl Tool for McpProxyTool {
 
     async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
         let arguments: Option<Map<String, Value>> = if params.is_null()
-            || params.is_object() && params.as_object().map(|o| o.is_empty()).unwrap_or(false)
+            || params.is_object() && params.as_object().is_some_and(Map::is_empty)
         {
             None
         } else {

--- a/crates/garudust-tools/src/toolsets/mcp.rs
+++ b/crates/garudust-tools/src/toolsets/mcp.rs
@@ -63,7 +63,7 @@ impl Tool for McpProxyTool {
         {
             None
         } else {
-            params.as_object().map(|o| o.clone())
+            params.as_object().cloned()
         };
 
         let mut req = CallToolRequestParams::new(self.tool_name.clone());

--- a/crates/garudust-tools/src/toolsets/mcp.rs
+++ b/crates/garudust-tools/src/toolsets/mcp.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use garudust_core::{
+    error::ToolError,
+    tool::{Tool, ToolContext},
+    types::ToolResult,
+};
+use rmcp::{
+    model::CallToolRequestParams,
+    service::{Peer, RoleClient},
+};
+use serde_json::{Map, Value};
+
+/// Wraps a single tool exposed by an external MCP server.
+pub struct McpProxyTool {
+    tool_name: String,
+    tool_description: String,
+    input_schema: Value,
+    server_name: String,
+    peer: Peer<RoleClient>,
+}
+
+impl McpProxyTool {
+    pub fn new(
+        tool_name: String,
+        tool_description: String,
+        input_schema: Value,
+        server_name: String,
+        peer: Peer<RoleClient>,
+    ) -> Self {
+        Self {
+            tool_name,
+            tool_description,
+            input_schema,
+            server_name,
+            peer,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpProxyTool {
+    fn name(&self) -> &str {
+        &self.tool_name
+    }
+
+    fn description(&self) -> &str {
+        &self.tool_description
+    }
+
+    fn toolset(&self) -> &str {
+        &self.server_name
+    }
+
+    fn schema(&self) -> Value {
+        self.input_schema.clone()
+    }
+
+    async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let arguments: Option<Map<String, Value>> = if params.is_null() || params.is_object()
+            && params.as_object().map(|o| o.is_empty()).unwrap_or(false)
+        {
+            None
+        } else {
+            params
+                .as_object()
+                .map(|o| o.clone())
+        };
+
+        let mut req = CallToolRequestParams::new(self.tool_name.clone());
+        req.arguments = arguments;
+
+        let result = self
+            .peer
+            .call_tool(req)
+            .await
+            .map_err(|e| ToolError::Execution(e.to_string()))?;
+
+        let text = result
+            .content
+            .iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let is_error = result.is_error.unwrap_or(false);
+        Ok(if is_error {
+            ToolResult::err(&self.tool_name, text)
+        } else {
+            ToolResult::ok(&self.tool_name, text)
+        })
+    }
+}
+
+/// Connect to an MCP server via stdio and return discovered tools plus an opaque
+/// keep-alive handle. The caller must hold the handle for the lifetime of the tools.
+pub async fn connect_mcp_server(
+    command: &str,
+    args: &[String],
+) -> anyhow::Result<(Vec<Arc<McpProxyTool>>, Box<dyn std::any::Any + Send>)> {
+    use rmcp::{transport::TokioChildProcess, ServiceExt};
+
+    let mut cmd = tokio::process::Command::new(command);
+    cmd.args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit());
+
+    let transport = TokioChildProcess::new(cmd)?;
+    let service: rmcp::service::RunningService<RoleClient, ()> =
+        ().serve(transport).await?;
+    let peer = service.peer().clone();
+    let server_name = command.to_string();
+
+    let mcp_tools: Vec<Arc<McpProxyTool>> = service
+        .list_all_tools()
+        .await?
+        .into_iter()
+        .map(|t| {
+            let input_schema = Value::Object((*t.input_schema).clone());
+            Arc::new(McpProxyTool::new(
+                t.name.to_string(),
+                t.description
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_string(),
+                input_schema,
+                server_name.clone(),
+                peer.clone(),
+            )) as Arc<McpProxyTool>
+        })
+        .collect();
+
+    Ok((mcp_tools, Box::new(service)))
+}

--- a/crates/garudust-tools/src/toolsets/mcp.rs
+++ b/crates/garudust-tools/src/toolsets/mcp.rs
@@ -58,14 +58,12 @@ impl Tool for McpProxyTool {
     }
 
     async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
-        let arguments: Option<Map<String, Value>> = if params.is_null() || params.is_object()
-            && params.as_object().map(|o| o.is_empty()).unwrap_or(false)
+        let arguments: Option<Map<String, Value>> = if params.is_null()
+            || params.is_object() && params.as_object().map(|o| o.is_empty()).unwrap_or(false)
         {
             None
         } else {
-            params
-                .as_object()
-                .map(|o| o.clone())
+            params.as_object().map(|o| o.clone())
         };
 
         let mut req = CallToolRequestParams::new(self.tool_name.clone());
@@ -108,8 +106,7 @@ pub async fn connect_mcp_server(
         .stderr(std::process::Stdio::inherit());
 
     let transport = TokioChildProcess::new(cmd)?;
-    let service: rmcp::service::RunningService<RoleClient, ()> =
-        ().serve(transport).await?;
+    let service: rmcp::service::RunningService<RoleClient, ()> = ().serve(transport).await?;
     let peer = service.peer().clone();
     let server_name = command.to_string();
 
@@ -121,10 +118,7 @@ pub async fn connect_mcp_server(
             let input_schema = Value::Object((*t.input_schema).clone());
             Arc::new(McpProxyTool::new(
                 t.name.to_string(),
-                t.description
-                    .as_deref()
-                    .unwrap_or("")
-                    .to_string(),
+                t.description.as_deref().unwrap_or("").to_string(),
                 input_schema,
                 server_name.clone(),
                 peer.clone(),

--- a/crates/garudust-tools/src/toolsets/mod.rs
+++ b/crates/garudust-tools/src/toolsets/mod.rs
@@ -1,5 +1,7 @@
 pub mod files;
+pub mod mcp;
 pub mod memory;
+pub mod search;
 pub mod skills;
 pub mod terminal;
 pub mod web;

--- a/crates/garudust-tools/src/toolsets/search.rs
+++ b/crates/garudust-tools/src/toolsets/search.rs
@@ -1,5 +1,9 @@
 use async_trait::async_trait;
-use garudust_core::{error::ToolError, tool::{Tool, ToolContext}, types::ToolResult};
+use garudust_core::{
+    error::ToolError,
+    tool::{Tool, ToolContext},
+    types::ToolResult,
+};
 use garudust_memory::SessionDb;
 use serde_json::json;
 

--- a/crates/garudust-tools/src/toolsets/search.rs
+++ b/crates/garudust-tools/src/toolsets/search.rs
@@ -1,0 +1,69 @@
+use async_trait::async_trait;
+use garudust_core::{error::ToolError, tool::{Tool, ToolContext}, types::ToolResult};
+use garudust_memory::SessionDb;
+use serde_json::json;
+
+pub struct SessionSearch;
+
+#[async_trait]
+impl Tool for SessionSearch {
+    fn name(&self) -> &'static str {
+        "session_search"
+    }
+    fn description(&self) -> &'static str {
+        "Full-text search across past conversation sessions stored in the local database"
+    }
+    fn toolset(&self) -> &'static str {
+        "memory"
+    }
+
+    fn schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query — supports FTS5 syntax (AND, OR, NOT, phrase)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum results to return (default 10, max 50)",
+                    "default": 10
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let query = params["query"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidArgs("'query' required".into()))?;
+
+        let limit = params["limit"].as_u64().unwrap_or(10).min(50) as usize;
+
+        let db = SessionDb::open(&ctx.config.home_dir)
+            .map_err(|e| ToolError::Execution(e.to_string()))?;
+
+        let results = db
+            .search(query, limit)
+            .map_err(|e| ToolError::Execution(e.to_string()))?;
+
+        if results.is_empty() {
+            return Ok(ToolResult::ok("", "No results found."));
+        }
+
+        let output = results
+            .iter()
+            .enumerate()
+            .map(|(i, content)| format!("[{}] {}", i + 1, content))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        Ok(ToolResult::ok("", output))
+    }
+}

--- a/crates/garudust-transport/Cargo.toml
+++ b/crates/garudust-transport/Cargo.toml
@@ -14,3 +14,4 @@ tracing       = { workspace = true }
 anyhow        = { workspace = true }
 thiserror     = { workspace = true }
 futures       = { workspace = true }
+async-stream  = { workspace = true }

--- a/crates/garudust-transport/src/anthropic.rs
+++ b/crates/garudust-transport/src/anthropic.rs
@@ -183,20 +183,16 @@ impl ProviderTransport for AnthropicTransport {
                 let bytes = chunk.map_err(|e| TransportError::Stream(e.to_string()))?;
                 buf.push_str(&String::from_utf8_lossy(&bytes));
 
-                loop {
-                    if let Some(pos) = buf.find('\n') {
-                        let line = buf[..pos].trim().to_string();
-                        buf = buf[pos + 1..].to_string();
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].trim().to_string();
+                    buf = buf[pos + 1..].to_string();
 
-                        if let Some(data) = line.strip_prefix("data: ") {
-                            if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
-                                for chunk in parse_anthropic_sse_event(&event) {
-                                    yield chunk;
-                                }
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
+                            for chunk in parse_anthropic_sse_event(&event) {
+                                yield chunk;
                             }
                         }
-                    } else {
-                        break;
                     }
                 }
             }

--- a/crates/garudust-transport/src/anthropic.rs
+++ b/crates/garudust-transport/src/anthropic.rs
@@ -247,8 +247,7 @@ fn parse_anthropic_sse_event(event: &serde_json::Value) -> Vec<StreamChunk> {
         }
         Some("message_delta") => {
             #[allow(clippy::cast_possible_truncation)]
-            let output_tokens =
-                event["usage"]["output_tokens"].as_u64().unwrap_or(0) as u32;
+            let output_tokens = event["usage"]["output_tokens"].as_u64().unwrap_or(0) as u32;
             chunks.push(StreamChunk::Done {
                 usage: TokenUsage {
                     output_tokens,

--- a/crates/garudust-transport/src/anthropic.rs
+++ b/crates/garudust-transport/src/anthropic.rs
@@ -25,7 +25,6 @@ impl AnthropicTransport {
     }
 
     fn build_body(
-        &self,
         messages: &[Message],
         config: &InferenceConfig,
         tools: &[ToolSchema],
@@ -116,7 +115,7 @@ impl ProviderTransport for AnthropicTransport {
         config: &InferenceConfig,
         tools: &[ToolSchema],
     ) -> Result<TransportResponse, TransportError> {
-        let body = self.build_body(messages, config, tools, false);
+        let body = Self::build_body(messages, config, tools, false);
 
         let resp = self
             .client
@@ -152,7 +151,7 @@ impl ProviderTransport for AnthropicTransport {
         config: &InferenceConfig,
         tools: &[ToolSchema],
     ) -> Result<StreamResult, TransportError> {
-        let body = self.build_body(messages, config, tools, true);
+        let body = Self::build_body(messages, config, tools, true);
 
         let resp = self
             .client
@@ -206,7 +205,7 @@ fn parse_anthropic_sse_event(event: &serde_json::Value) -> Vec<StreamChunk> {
     let mut chunks = Vec::new();
     match event["type"].as_str() {
         Some("content_block_start") => {
-            let index = event["index"].as_u64().unwrap_or(0) as usize;
+            let index = usize::try_from(event["index"].as_u64().unwrap_or(0)).unwrap_or(0);
             let block = &event["content_block"];
             if block["type"].as_str() == Some("tool_use") {
                 chunks.push(StreamChunk::ToolCallDelta {
@@ -218,7 +217,7 @@ fn parse_anthropic_sse_event(event: &serde_json::Value) -> Vec<StreamChunk> {
             }
         }
         Some("content_block_delta") => {
-            let index = event["index"].as_u64().unwrap_or(0) as usize;
+            let index = usize::try_from(event["index"].as_u64().unwrap_or(0)).unwrap_or(0);
             let delta = &event["delta"];
             match delta["type"].as_str() {
                 Some("text_delta") => {
@@ -256,6 +255,7 @@ fn parse_anthropic_sse_event(event: &serde_json::Value) -> Vec<StreamChunk> {
     chunks
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn parse_response(data: &serde_json::Value) -> Result<TransportResponse, TransportError> {
     let stop_reason = match data["stop_reason"].as_str() {
         Some("end_turn") | None => StopReason::EndTurn,

--- a/crates/garudust-transport/src/anthropic.rs
+++ b/crates/garudust-transport/src/anthropic.rs
@@ -1,10 +1,12 @@
+use async_stream::try_stream;
 use async_trait::async_trait;
+use futures::StreamExt;
 use garudust_core::{
     error::TransportError,
     transport::{ApiMode, ProviderTransport, StreamResult},
     types::{
-        ContentPart, InferenceConfig, Message, Role, StopReason, TokenUsage, ToolCall, ToolSchema,
-        TransportResponse,
+        ContentPart, InferenceConfig, Message, Role, StopReason, StreamChunk, TokenUsage, ToolCall,
+        ToolSchema, TransportResponse,
     },
 };
 use serde_json::json;
@@ -21,20 +23,14 @@ impl AnthropicTransport {
             api_key,
         }
     }
-}
 
-#[async_trait]
-impl ProviderTransport for AnthropicTransport {
-    fn api_mode(&self) -> ApiMode {
-        ApiMode::AnthropicMessages
-    }
-
-    async fn chat(
+    fn build_body(
         &self,
         messages: &[Message],
         config: &InferenceConfig,
         tools: &[ToolSchema],
-    ) -> Result<TransportResponse, TransportError> {
+        stream: bool,
+    ) -> serde_json::Value {
         let system = messages
             .iter()
             .filter(|m| m.role == Role::System)
@@ -42,35 +38,42 @@ impl ProviderTransport for AnthropicTransport {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let msgs: Vec<_> =
-            messages
-                .iter()
-                .filter(|m| m.role != Role::System)
-                .map(|m| {
-                    let role = match m.role {
-                        Role::User | Role::Tool => "user",
-                        Role::Assistant => "assistant",
-                        Role::System => unreachable!(),
-                    };
-                    let content: Vec<_> = m.content.iter().map(|p| match p {
-                    ContentPart::Text(t) => json!({ "type": "text", "text": t }),
-                    ContentPart::ToolUse { id, name, input } => json!({
-                        "type": "tool_use", "id": id, "name": name, "input": input
-                    }),
-                    ContentPart::ToolResult { tool_use_id, content, is_error } => json!({
-                        "type": "tool_result",
-                        "tool_use_id": tool_use_id,
-                        "content": content,
-                        "is_error": is_error,
-                    }),
-                    ContentPart::Image { mime_type, data } => json!({
-                        "type": "image",
-                        "source": { "type": "base64", "media_type": mime_type, "data": data }
-                    }),
-                }).collect();
-                    json!({ "role": role, "content": content })
-                })
-                .collect();
+        let msgs: Vec<_> = messages
+            .iter()
+            .filter(|m| m.role != Role::System)
+            .map(|m| {
+                let role = match m.role {
+                    Role::User | Role::Tool => "user",
+                    Role::Assistant => "assistant",
+                    Role::System => unreachable!(),
+                };
+                let content: Vec<_> = m
+                    .content
+                    .iter()
+                    .map(|p| match p {
+                        ContentPart::Text(t) => json!({ "type": "text", "text": t }),
+                        ContentPart::ToolUse { id, name, input } => {
+                            json!({ "type": "tool_use", "id": id, "name": name, "input": input })
+                        }
+                        ContentPart::ToolResult {
+                            tool_use_id,
+                            content,
+                            is_error,
+                        } => json!({
+                            "type": "tool_result",
+                            "tool_use_id": tool_use_id,
+                            "content": content,
+                            "is_error": is_error,
+                        }),
+                        ContentPart::Image { mime_type, data } => json!({
+                            "type": "image",
+                            "source": { "type": "base64", "media_type": mime_type, "data": data }
+                        }),
+                    })
+                    .collect();
+                json!({ "role": role, "content": content })
+            })
+            .collect();
 
         let anthropic_tools: Vec<_> = tools
             .iter()
@@ -88,12 +91,32 @@ impl ProviderTransport for AnthropicTransport {
             "max_tokens": config.max_tokens.unwrap_or(8192),
             "messages":   msgs,
         });
+        if stream {
+            body["stream"] = json!(true);
+        }
         if !system.is_empty() {
             body["system"] = json!(system);
         }
         if !anthropic_tools.is_empty() {
             body["tools"] = json!(anthropic_tools);
         }
+        body
+    }
+}
+
+#[async_trait]
+impl ProviderTransport for AnthropicTransport {
+    fn api_mode(&self) -> ApiMode {
+        ApiMode::AnthropicMessages
+    }
+
+    async fn chat(
+        &self,
+        messages: &[Message],
+        config: &InferenceConfig,
+        tools: &[ToolSchema],
+    ) -> Result<TransportResponse, TransportError> {
+        let body = self.build_body(messages, config, tools, false);
 
         let resp = self
             .client
@@ -108,7 +131,11 @@ impl ProviderTransport for AnthropicTransport {
         if !resp.status().is_success() {
             let status = resp.status().as_u16();
             let body = resp.text().await.unwrap_or_default();
-            return Err(TransportError::Http { status, body });
+            return Err(if status == 401 {
+                TransportError::Auth
+            } else {
+                TransportError::Http { status, body }
+            });
         }
 
         let data: serde_json::Value = resp
@@ -116,63 +143,171 @@ impl ProviderTransport for AnthropicTransport {
             .await
             .map_err(|e| TransportError::Other(anyhow::anyhow!("{e}")))?;
 
-        let stop_reason = match data["stop_reason"].as_str() {
-            Some("end_turn") | None => StopReason::EndTurn,
-            Some("tool_use") => StopReason::ToolUse,
-            Some("max_tokens") => StopReason::MaxTokens,
-            Some(other) => StopReason::Other(other.into()),
-        };
-
-        let mut content = Vec::new();
-        let mut tool_calls = Vec::new();
-
-        if let Some(arr) = data["content"].as_array() {
-            for block in arr {
-                match block["type"].as_str() {
-                    Some("text") => {
-                        if let Some(t) = block["text"].as_str() {
-                            content.push(ContentPart::Text(t.into()));
-                        }
-                    }
-                    Some("tool_use") => {
-                        tool_calls.push(ToolCall {
-                            id: block["id"].as_str().unwrap_or("").into(),
-                            name: block["name"].as_str().unwrap_or("").into(),
-                            arguments: block["input"].clone(),
-                        });
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        #[allow(clippy::cast_possible_truncation)]
-        let usage = TokenUsage {
-            input_tokens: data["usage"]["input_tokens"].as_u64().unwrap_or(0) as u32,
-            output_tokens: data["usage"]["output_tokens"].as_u64().unwrap_or(0) as u32,
-            cache_read_tokens: data["usage"]["cache_read_input_tokens"]
-                .as_u64()
-                .unwrap_or(0) as u32,
-            cache_write_tokens: data["usage"]["cache_creation_input_tokens"]
-                .as_u64()
-                .unwrap_or(0) as u32,
-        };
-
-        Ok(TransportResponse {
-            content,
-            tool_calls,
-            usage,
-            stop_reason,
-        })
+        parse_response(&data)
     }
 
     async fn chat_stream(
         &self,
-        _messages: &[Message],
-        _config: &InferenceConfig,
+        messages: &[Message],
+        config: &InferenceConfig,
+        tools: &[ToolSchema],
     ) -> Result<StreamResult, TransportError> {
-        Err(TransportError::Other(anyhow::anyhow!(
-            "streaming not yet implemented"
-        )))
+        let body = self.build_body(messages, config, tools, true);
+
+        let resp = self
+            .client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| TransportError::Other(anyhow::anyhow!("{e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(if status == 401 {
+                TransportError::Auth
+            } else {
+                TransportError::Http { status, body }
+            });
+        }
+
+        let mut byte_stream = resp.bytes_stream();
+
+        let stream = try_stream! {
+            let mut buf = String::new();
+
+            while let Some(chunk) = byte_stream.next().await {
+                let bytes = chunk.map_err(|e| TransportError::Stream(e.to_string()))?;
+                buf.push_str(&String::from_utf8_lossy(&bytes));
+
+                loop {
+                    if let Some(pos) = buf.find('\n') {
+                        let line = buf[..pos].trim().to_string();
+                        buf = buf[pos + 1..].to_string();
+
+                        if let Some(data) = line.strip_prefix("data: ") {
+                            if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
+                                for chunk in parse_anthropic_sse_event(&event) {
+                                    yield chunk;
+                                }
+                            }
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Box::pin(stream))
     }
+}
+
+fn parse_anthropic_sse_event(event: &serde_json::Value) -> Vec<StreamChunk> {
+    let mut chunks = Vec::new();
+    match event["type"].as_str() {
+        Some("content_block_start") => {
+            let index = event["index"].as_u64().unwrap_or(0) as usize;
+            let block = &event["content_block"];
+            if block["type"].as_str() == Some("tool_use") {
+                chunks.push(StreamChunk::ToolCallDelta {
+                    index,
+                    id: block["id"].as_str().map(str::to_string),
+                    name: block["name"].as_str().map(str::to_string),
+                    args_delta: String::new(),
+                });
+            }
+        }
+        Some("content_block_delta") => {
+            let index = event["index"].as_u64().unwrap_or(0) as usize;
+            let delta = &event["delta"];
+            match delta["type"].as_str() {
+                Some("text_delta") => {
+                    if let Some(text) = delta["text"].as_str() {
+                        if !text.is_empty() {
+                            chunks.push(StreamChunk::TextDelta(text.to_string()));
+                        }
+                    }
+                }
+                Some("input_json_delta") => {
+                    if let Some(partial) = delta["partial_json"].as_str() {
+                        chunks.push(StreamChunk::ToolCallDelta {
+                            index,
+                            id: None,
+                            name: None,
+                            args_delta: partial.to_string(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+        Some("message_delta") => {
+            #[allow(clippy::cast_possible_truncation)]
+            let output_tokens =
+                event["usage"]["output_tokens"].as_u64().unwrap_or(0) as u32;
+            chunks.push(StreamChunk::Done {
+                usage: TokenUsage {
+                    output_tokens,
+                    ..Default::default()
+                },
+            });
+        }
+        _ => {}
+    }
+    chunks
+}
+
+fn parse_response(data: &serde_json::Value) -> Result<TransportResponse, TransportError> {
+    let stop_reason = match data["stop_reason"].as_str() {
+        Some("end_turn") | None => StopReason::EndTurn,
+        Some("tool_use") => StopReason::ToolUse,
+        Some("max_tokens") => StopReason::MaxTokens,
+        Some(other) => StopReason::Other(other.into()),
+    };
+
+    let mut content = Vec::new();
+    let mut tool_calls = Vec::new();
+
+    if let Some(arr) = data["content"].as_array() {
+        for block in arr {
+            match block["type"].as_str() {
+                Some("text") => {
+                    if let Some(t) = block["text"].as_str() {
+                        content.push(ContentPart::Text(t.into()));
+                    }
+                }
+                Some("tool_use") => {
+                    tool_calls.push(ToolCall {
+                        id: block["id"].as_str().unwrap_or("").into(),
+                        name: block["name"].as_str().unwrap_or("").into(),
+                        arguments: block["input"].clone(),
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    let usage = TokenUsage {
+        input_tokens: data["usage"]["input_tokens"].as_u64().unwrap_or(0) as u32,
+        output_tokens: data["usage"]["output_tokens"].as_u64().unwrap_or(0) as u32,
+        cache_read_tokens: data["usage"]["cache_read_input_tokens"]
+            .as_u64()
+            .unwrap_or(0) as u32,
+        cache_write_tokens: data["usage"]["cache_creation_input_tokens"]
+            .as_u64()
+            .unwrap_or(0) as u32,
+    };
+
+    Ok(TransportResponse {
+        content,
+        tool_calls,
+        usage,
+        stop_reason,
+    })
 }

--- a/crates/garudust-transport/src/chat_completions.rs
+++ b/crates/garudust-transport/src/chat_completions.rs
@@ -1,10 +1,12 @@
+use async_stream::try_stream;
 use async_trait::async_trait;
+use futures::StreamExt;
 use garudust_core::{
     error::TransportError,
     transport::{ApiMode, ProviderTransport, StreamResult},
     types::{
-        ContentPart, InferenceConfig, Message, Role, StopReason, TokenUsage, ToolCall, ToolSchema,
-        TransportResponse,
+        ContentPart, InferenceConfig, Message, Role, StopReason, StreamChunk, TokenUsage, ToolCall,
+        ToolSchema, TransportResponse,
     },
 };
 use serde_json::{json, Value};
@@ -216,11 +218,126 @@ impl ProviderTransport for ChatCompletionsTransport {
 
     async fn chat_stream(
         &self,
-        _messages: &[Message],
-        _config: &InferenceConfig,
+        messages: &[Message],
+        config: &InferenceConfig,
+        tools: &[ToolSchema],
     ) -> Result<StreamResult, TransportError> {
-        Err(TransportError::Other(anyhow::anyhow!(
-            "streaming not yet implemented"
-        )))
+        let oai_messages = messages_to_json(messages);
+        let oai_tools = tools_to_json(tools);
+
+        let mut body = json!({
+            "model":                 config.model,
+            "messages":              oai_messages,
+            "max_completion_tokens": config.max_tokens.unwrap_or(8192),
+            "stream":                true,
+            "stream_options":        { "include_usage": true },
+        });
+        if let Some(t) = config.temperature {
+            body["temperature"] = json!(t);
+        }
+        if !oai_tools.is_empty() {
+            body["tools"] = json!(oai_tools);
+        }
+
+        let resp = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| TransportError::Other(anyhow::anyhow!("{e}")))?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(classify_error(status, &text));
+        }
+
+        let mut byte_stream = resp.bytes_stream();
+
+        let stream = try_stream! {
+            let mut buf = String::new();
+            // tool call accumulator: index → (id, name, args)
+            let mut tc_acc: Vec<(String, String, String)> = Vec::new();
+
+            while let Some(chunk) = byte_stream.next().await {
+                let bytes = chunk.map_err(|e| TransportError::Stream(e.to_string()))?;
+                buf.push_str(&String::from_utf8_lossy(&bytes));
+
+                loop {
+                    if let Some(pos) = buf.find('\n') {
+                        let line = buf[..pos].trim().to_string();
+                        buf = buf[pos + 1..].to_string();
+
+                        let data = match line.strip_prefix("data: ") {
+                            Some(d) => d.to_string(),
+                            None => continue,
+                        };
+                        if data == "[DONE]" { break; }
+
+                        let Ok(event) = serde_json::from_str::<Value>(&data) else { continue };
+                        let choice = match event["choices"].as_array().and_then(|a| a.first()) {
+                            Some(c) => c.clone(),
+                            None => {
+                                // usage-only chunk
+                                #[allow(clippy::cast_possible_truncation)]
+                                if let (Some(p), Some(c)) = (
+                                    event["usage"]["prompt_tokens"].as_u64(),
+                                    event["usage"]["completion_tokens"].as_u64(),
+                                ) {
+                                    yield StreamChunk::Done {
+                                        usage: TokenUsage {
+                                            input_tokens: p as u32,
+                                            output_tokens: c as u32,
+                                            ..Default::default()
+                                        },
+                                    };
+                                }
+                                continue;
+                            }
+                        };
+
+                        let delta = &choice["delta"];
+
+                        if let Some(text) = delta["content"].as_str() {
+                            if !text.is_empty() {
+                                yield StreamChunk::TextDelta(text.to_string());
+                            }
+                        }
+
+                        if let Some(tcs) = delta["tool_calls"].as_array() {
+                            for tc in tcs {
+                                let index = tc["index"].as_u64().unwrap_or(0) as usize;
+                                while tc_acc.len() <= index {
+                                    tc_acc.push((String::new(), String::new(), String::new()));
+                                }
+                                if let Some(id) = tc["id"].as_str() {
+                                    tc_acc[index].0 = id.to_string();
+                                }
+                                if let Some(name) = tc["function"]["name"].as_str() {
+                                    tc_acc[index].1 = name.to_string();
+                                }
+                                if let Some(args) = tc["function"]["arguments"].as_str() {
+                                    let entry = &mut tc_acc[index];
+                                    let is_first = entry.0.is_empty() && entry.1.is_empty();
+                                    yield StreamChunk::ToolCallDelta {
+                                        index,
+                                        id: if is_first { tc["id"].as_str().map(str::to_string) } else { None },
+                                        name: if is_first { tc["function"]["name"].as_str().map(str::to_string) } else { None },
+                                        args_delta: args.to_string(),
+                                    };
+                                    entry.2.push_str(args);
+                                }
+                            }
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Box::pin(stream))
     }
 }

--- a/crates/garudust-transport/src/chat_completions.rs
+++ b/crates/garudust-transport/src/chat_completions.rs
@@ -265,74 +265,83 @@ impl ProviderTransport for ChatCompletionsTransport {
                 let bytes = chunk.map_err(|e| TransportError::Stream(e.to_string()))?;
                 buf.push_str(&String::from_utf8_lossy(&bytes));
 
-                loop {
-                    if let Some(pos) = buf.find('\n') {
-                        let line = buf[..pos].trim().to_string();
-                        buf = buf[pos + 1..].to_string();
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].trim().to_string();
+                    buf = buf[pos + 1..].to_string();
 
-                        let data = match line.strip_prefix("data: ") {
-                            Some(d) => d.to_string(),
-                            None => continue,
-                        };
-                        if data == "[DONE]" { break; }
-
-                        let Ok(event) = serde_json::from_str::<Value>(&data) else { continue };
-                        let choice = match event["choices"].as_array().and_then(|a| a.first()) {
-                            Some(c) => c.clone(),
-                            None => {
-                                // usage-only chunk
-                                #[allow(clippy::cast_possible_truncation)]
-                                if let (Some(p), Some(c)) = (
-                                    event["usage"]["prompt_tokens"].as_u64(),
-                                    event["usage"]["completion_tokens"].as_u64(),
-                                ) {
-                                    yield StreamChunk::Done {
-                                        usage: TokenUsage {
-                                            input_tokens: p as u32,
-                                            output_tokens: c as u32,
-                                            ..Default::default()
-                                        },
-                                    };
-                                }
-                                continue;
-                            }
-                        };
-
-                        let delta = &choice["delta"];
-
-                        if let Some(text) = delta["content"].as_str() {
-                            if !text.is_empty() {
-                                yield StreamChunk::TextDelta(text.to_string());
-                            }
-                        }
-
-                        if let Some(tcs) = delta["tool_calls"].as_array() {
-                            for tc in tcs {
-                                let index = tc["index"].as_u64().unwrap_or(0) as usize;
-                                while tc_acc.len() <= index {
-                                    tc_acc.push((String::new(), String::new(), String::new()));
-                                }
-                                if let Some(id) = tc["id"].as_str() {
-                                    tc_acc[index].0 = id.to_string();
-                                }
-                                if let Some(name) = tc["function"]["name"].as_str() {
-                                    tc_acc[index].1 = name.to_string();
-                                }
-                                if let Some(args) = tc["function"]["arguments"].as_str() {
-                                    let entry = &mut tc_acc[index];
-                                    let is_first = entry.0.is_empty() && entry.1.is_empty();
-                                    yield StreamChunk::ToolCallDelta {
-                                        index,
-                                        id: if is_first { tc["id"].as_str().map(str::to_string) } else { None },
-                                        name: if is_first { tc["function"]["name"].as_str().map(str::to_string) } else { None },
-                                        args_delta: args.to_string(),
-                                    };
-                                    entry.2.push_str(args);
-                                }
-                            }
-                        }
-                    } else {
+                    let Some(d) = line.strip_prefix("data: ") else {
+                        continue;
+                    };
+                    let data = d.to_string();
+                    if data == "[DONE]" {
                         break;
+                    }
+
+                    let Ok(event) = serde_json::from_str::<Value>(&data) else {
+                        continue;
+                    };
+                    let choice = match event["choices"].as_array().and_then(|a| a.first()) {
+                        Some(c) => c.clone(),
+                        None => {
+                            // usage-only chunk
+                            #[allow(clippy::cast_possible_truncation)]
+                            if let (Some(p), Some(c)) = (
+                                event["usage"]["prompt_tokens"].as_u64(),
+                                event["usage"]["completion_tokens"].as_u64(),
+                            ) {
+                                yield StreamChunk::Done {
+                                    usage: TokenUsage {
+                                        input_tokens: p as u32,
+                                        output_tokens: c as u32,
+                                        ..Default::default()
+                                    },
+                                };
+                            }
+                            continue;
+                        }
+                    };
+
+                    let delta = &choice["delta"];
+
+                    if let Some(text) = delta["content"].as_str() {
+                        if !text.is_empty() {
+                            yield StreamChunk::TextDelta(text.to_string());
+                        }
+                    }
+
+                    if let Some(tcs) = delta["tool_calls"].as_array() {
+                        for tc in tcs {
+                            #[allow(clippy::cast_possible_truncation)]
+                            let index = tc["index"].as_u64().unwrap_or(0) as usize;
+                            while tc_acc.len() <= index {
+                                tc_acc.push((String::new(), String::new(), String::new()));
+                            }
+                            if let Some(id) = tc["id"].as_str() {
+                                tc_acc[index].0 = id.to_string();
+                            }
+                            if let Some(name) = tc["function"]["name"].as_str() {
+                                tc_acc[index].1 = name.to_string();
+                            }
+                            if let Some(args) = tc["function"]["arguments"].as_str() {
+                                let entry = &mut tc_acc[index];
+                                let is_first = entry.0.is_empty() && entry.1.is_empty();
+                                yield StreamChunk::ToolCallDelta {
+                                    index,
+                                    id: if is_first {
+                                        tc["id"].as_str().map(str::to_string)
+                                    } else {
+                                        None
+                                    },
+                                    name: if is_first {
+                                        tc["function"]["name"].as_str().map(str::to_string)
+                                    } else {
+                                        None
+                                    },
+                                    args_delta: args.to_string(),
+                                };
+                                entry.2.push_str(args);
+                            }
+                        }
                     }
                 }
             }

--- a/crates/garudust-transport/src/chat_completions.rs
+++ b/crates/garudust-transport/src/chat_completions.rs
@@ -280,26 +280,26 @@ impl ProviderTransport for ChatCompletionsTransport {
                     let Ok(event) = serde_json::from_str::<Value>(&data) else {
                         continue;
                     };
-                    let choice = match event["choices"].as_array().and_then(|a| a.first()) {
-                        Some(c) => c.clone(),
-                        None => {
-                            // usage-only chunk
-                            #[allow(clippy::cast_possible_truncation)]
-                            if let (Some(p), Some(c)) = (
-                                event["usage"]["prompt_tokens"].as_u64(),
-                                event["usage"]["completion_tokens"].as_u64(),
-                            ) {
-                                yield StreamChunk::Done {
-                                    usage: TokenUsage {
-                                        input_tokens: p as u32,
-                                        output_tokens: c as u32,
-                                        ..Default::default()
-                                    },
-                                };
-                            }
-                            continue;
+                    let Some(choice_ref) =
+                        event["choices"].as_array().and_then(|a| a.first())
+                    else {
+                        // usage-only chunk
+                        #[allow(clippy::cast_possible_truncation)]
+                        if let (Some(p), Some(c)) = (
+                            event["usage"]["prompt_tokens"].as_u64(),
+                            event["usage"]["completion_tokens"].as_u64(),
+                        ) {
+                            yield StreamChunk::Done {
+                                usage: TokenUsage {
+                                    input_tokens: p as u32,
+                                    output_tokens: c as u32,
+                                    ..Default::default()
+                                },
+                            };
                         }
+                        continue;
                     };
+                    let choice = choice_ref.clone();
 
                     let delta = &choice["delta"];
 


### PR DESCRIPTION
## Summary

- **Streaming output** — `chat_stream()` implemented in both Anthropic and OpenAI-compat transports (SSE byte parsing, tool-call delta accumulation). `Agent::run_streaming()` forwards `TextDelta` chunks via `mpsc::UnboundedSender<String>`. TUI renders tokens live as they arrive via `AgentEvent::OutputChunk`.

- **Slash commands** — TUI Enter handler detects `/` prefix and dispatches `/new` (clear history), `/model <name>` (rebuild agent with new model, no restart needed), `/help`. New `TuiEvent::NewSession` / `TuiEvent::ChangeModel(String)` variants handled in the event loop.

- **MCP integration** — `McpProxyTool` wraps any tool discovered from an MCP server. `connect_mcp_server(command, args)` spawns the process via `TokioChildProcess`, negotiates, and returns proxy tools + opaque keep-alive handle. Both `garudust` and `garudust-server` call `attach_mcp_servers()` at startup. Configure via `mcp_servers` in `~/.garudust/config.yaml`.

- **`session_search` tool** — FTS5 full-text search over past sessions, registered in both binaries. Supports FTS5 query syntax (AND, OR, NOT, phrase).

## Foundation changes

- `Tool` trait: `name/description/toolset` now return `&str` (was `&'static str`) to support dynamic MCP tool names
- `ToolRegistry`: keys changed from `&'static str` to `String`; new `register_arc(Arc<dyn Tool>)` for runtime-discovered tools
- `AgentConfig`: new `mcp_servers: Vec<McpServerConfig>` field (serde default = empty)

## Test plan

- [ ] `cargo check` — passes (no warnings)
- [ ] TUI: type a task → tokens stream in real-time as AI responds
- [ ] TUI: `/help` shows command list; `/new` clears chat; `/model <name>` switches model without restart
- [ ] `session_search` appears in tool list; after at least one completed session, query returns results
- [ ] Add an MCP server to `config.yaml` under `mcp_servers:` — its tools appear in the registry at startup
- [ ] No regression on one-shot CLI mode (`garudust "some task"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)