### PR TITLE
feat: Slack and Matrix platform adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
 name = "aquamarine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,12 +140,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "as_variant"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
+
+[[package]]
+name = "assign"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -259,6 +305,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +341,26 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -314,6 +394,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "camino"
@@ -378,10 +464,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg-vis"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a2c3bf5fc10fe2ca157564fbe08a4cb2b0a7d2ff3fe2f9683e65d5e7c7859c"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "chromiumoxide"
@@ -464,6 +586,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +668,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +728,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -640,6 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -763,6 +930,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -872,6 +1040,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eyeball"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93bd0ebf93d61d6332d3c09a96e97975968a44e19a64c947bde06e6baff383f"
+dependencies = [
+ "futures-core",
+ "readlock",
+ "tracing",
+]
+
+[[package]]
+name = "eyeball-im"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9326c8d9f6d59d18935412608b4514cc661e4e068011bb2f523f6c8b1cfa3bd4"
+dependencies = [
+ "futures-core",
+ "imbl",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1200,6 +1424,7 @@ dependencies = [
  "futures",
  "garudust-agent",
  "garudust-core",
+ "matrix-sdk",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1207,6 +1432,7 @@ dependencies = [
  "teloxide",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tracing",
 ]
 
@@ -1328,6 +1554,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1649,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1532,6 +1779,20 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1744,6 +2005,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "imbl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978d142c8028edf52095703af2fad11d6f611af1246685725d6b850634647085"
+dependencies = [
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +2088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +2107,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1872,6 +2174,44 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "js_int"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d937f95470b270ce8b8950207715d71aa8e153c0d44c6684d59397ed4949160a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "js_option"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "konst"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97feab15b395d1860944abe6a8dd8ed9f8eadfae01750fada8427abda531d887"
+dependencies = [
+ "const_panic",
+ "konst_kernel",
+ "typewit",
+]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -1990,6 +2330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2351,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrix-sdk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336687e5fc8b33661a31681e988a67e9a3090c7fb1a8323a7f71eeaabad642ec"
+dependencies = [
+ "anymap2",
+ "aquamarine",
+ "as_variant",
+ "async-channel",
+ "async-stream",
+ "async-trait",
+ "backoff",
+ "bytes",
+ "bytesize",
+ "cfg-vis",
+ "event-listener 4.0.3",
+ "eyeball",
+ "eyeball-im",
+ "futures-core",
+ "futures-util",
+ "gloo-timers",
+ "http 0.2.12",
+ "imbl",
+ "indexmap",
+ "matrix-sdk-base",
+ "matrix-sdk-common",
+ "mime",
+ "mime2ext",
+ "reqwest 0.11.27",
+ "ruma",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "urlencoding",
+ "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-base"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00891954d0826a94f1d130f46cbca64176003a234c1be5d9d282970d31cf0c87"
+dependencies = [
+ "as_variant",
+ "async-trait",
+ "bitflags 2.11.1",
+ "eyeball",
+ "eyeball-im",
+ "futures-util",
+ "matrix-sdk-common",
+ "matrix-sdk-store-encryption",
+ "once_cell",
+ "ruma",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "matrix-sdk-common"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb365a626ab6f6c6a2422cfe2565522f19accb06706c6d04bca8f0f71df29c9f"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "futures-util",
+ "gloo-timers",
+ "instant",
+ "ruma",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "matrix-sdk-store-encryption"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7e3162e9f982a4c57ab46df01a4775f697dec8899738bf62d7e97b63faa61c"
+dependencies = [
+ "blake3",
+ "chacha20poly1305",
+ "displaydoc",
+ "hmac",
+ "pbkdf2",
+ "rand 0.8.6",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2471,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime2ext"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf6f36070878c42c5233846cd3de24cf9016828fd47bc22957a687298bb21fc"
 
 [[package]]
 name = "mime_guess"
@@ -2171,6 +2633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2728,16 @@ name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2300,6 +2784,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2826,26 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -2527,6 +3042,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,6 +3079,12 @@ checksum = "897fecc9fac6febd4408f9e935e86df739b0023b625e610e0357535b9c8adad0"
 dependencies = [
  "erasable",
 ]
+
+[[package]]
+name = "readlock"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da6f291b23556edd9edaf655a0be2ad8ef8002ff5f1bca62b264f3f58b53f34"
 
 [[package]]
 name = "redox_syscall"
@@ -2649,6 +3179,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -2659,6 +3190,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2667,6 +3199,7 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -2674,6 +3207,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -2693,7 +3227,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls",
+ "hyper-rustls 0.27.9",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
@@ -2777,6 +3311,150 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "ruma"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2779c38df072964c63476259d9300efb07d0d1a7178c6469893636ce0c547a36"
+dependencies = [
+ "assign",
+ "js_int",
+ "js_option",
+ "ruma-client-api",
+ "ruma-common",
+ "ruma-events",
+ "ruma-federation-api",
+]
+
+[[package]]
+name = "ruma-client-api"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641837258fa214a70823477514954ef0f5d3bc6ae8e1d5d85081856a33103386"
+dependencies = [
+ "assign",
+ "bytes",
+ "http 0.2.12",
+ "js_int",
+ "js_option",
+ "maplit",
+ "ruma-common",
+ "ruma-events",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+]
+
+[[package]]
+name = "ruma-common"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bca4c33c50e47b4cdceeac71bdef0c04153b0e29aa992d9030ec14a62323e85"
+dependencies = [
+ "as_variant",
+ "base64 0.21.7",
+ "bytes",
+ "form_urlencoded",
+ "http 0.2.12",
+ "indexmap",
+ "js_int",
+ "konst",
+ "percent-encoding",
+ "rand 0.8.6",
+ "regex",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "uuid",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-events"
+version = "0.27.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20a52770e5a9fb30b7a1c14ba8b3dcf76dadc01674e58e40094f78e6bd5e3f1"
+dependencies = [
+ "as_variant",
+ "indexmap",
+ "js_int",
+ "js_option",
+ "percent-encoding",
+ "regex",
+ "ruma-common",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-federation-api"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1901c1f27bc327652d58af2a130c73acef3198abeccd24cee97f7267fdf3fe7"
+dependencies = [
+ "js_int",
+ "ruma-common",
+ "ruma-events",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ruma-identifiers-validation"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa38974f5901ed4e00e10aec57b9ad3b4d6d6c1a1ae683c51b88700b9f4ffba"
+dependencies = [
+ "js_int",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ruma-macros"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0280534a4b3e34416f883285fac4f9c408cd0b737890ae66f3e7a7056d14be80"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 2.0.2",
+ "proc-macro2",
+ "quote",
+ "ruma-identifiers-validation",
+ "serde",
+ "syn 2.0.117",
+ "toml",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,6 +3511,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -2876,6 +3566,16 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2961,6 +3661,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secrecy"
@@ -3056,6 +3766,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,6 +3800,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3170,7 +3902,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3674,6 +4417,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
@@ -3723,6 +4476,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -3744,6 +4511,51 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3909,6 +4721,25 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -3965,6 +4796,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+dependencies = [
+ "typewit_proc_macros",
+]
+
+[[package]]
+name = "typewit_proc_macros"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4858,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4891,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -4256,6 +5118,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
@@ -4283,6 +5151,12 @@ dependencies = [
  "rustix 0.38.44",
  "winsafe",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 
 [[package]]
 name = "winapi"
@@ -4668,6 +5542,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4862,6 +5745,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,7 @@ notify   = { version = "6", features = ["macos_fsevent"] }
 
 # Browser / CDP
 chromiumoxide = { version = "0.7", default-features = false, features = ["tokio-runtime"] }
+
+# Platform SDKs (Slack / Matrix)
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+matrix-sdk        = { version = "0.7", default-features = false, features = ["rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ curl -X POST http://localhost:3000/chat/stream \
 | `GARUDUST_WEBHOOK_PORT` | `3001` | Webhook adapter port (`0` = disabled) |
 | `TELEGRAM_TOKEN` | — | Telegram bot token |
 | `DISCORD_TOKEN` | — | Discord bot token |
+| `SLACK_BOT_TOKEN` | — | Slack bot token (`xoxb-…`) |
+| `SLACK_APP_TOKEN` | — | Slack app-level token for Socket Mode (`xapp-…`) |
+| `MATRIX_HOMESERVER` | — | Matrix homeserver URL (e.g. `https://matrix.org`) |
+| `MATRIX_USER` | — | Matrix username (e.g. `@bot:matrix.org`) |
+| `MATRIX_PASSWORD` | — | Matrix password |
 | `GARUDUST_CRON_JOBS` | — | Comma-separated `"cron_expr=task"` pairs |
 | `RUST_LOG` | `info` | Log level (`debug` for verbose) |
 
@@ -314,7 +319,9 @@ Shipped:
 - [x] Browser tool — CDP via `chromiumoxide`
 
 Up next:
-- [ ] Slack and Matrix platform adapters
+- [x] Slack and Matrix platform adapters
+
+> All roadmap items shipped. See [issues](https://github.com/ninenox/garudust/issues) for what's next.
 
 ---
 

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -10,7 +10,8 @@ use garudust_cron::CronScheduler;
 use garudust_gateway::{create_router, AppState, GatewayHandler, Metrics, SessionRegistry};
 use garudust_memory::{FileMemoryStore, SessionDb};
 use garudust_platforms::{
-    discord::DiscordAdapter, telegram::TelegramAdapter, webhook::WebhookAdapter,
+    discord::DiscordAdapter, matrix::MatrixAdapter, slack::SlackAdapter, telegram::TelegramAdapter,
+    webhook::WebhookAdapter,
 };
 use garudust_tools::{
     toolsets::{
@@ -59,6 +60,21 @@ struct Cli {
 
     #[arg(long, env = "DISCORD_TOKEN")]
     discord_token: Option<String>,
+
+    #[arg(long, env = "SLACK_BOT_TOKEN")]
+    slack_bot_token: Option<String>,
+
+    #[arg(long, env = "SLACK_APP_TOKEN")]
+    slack_app_token: Option<String>,
+
+    #[arg(long, env = "MATRIX_HOMESERVER")]
+    matrix_homeserver: Option<String>,
+
+    #[arg(long, env = "MATRIX_USER")]
+    matrix_user: Option<String>,
+
+    #[arg(long, env = "MATRIX_PASSWORD")]
+    matrix_password: Option<String>,
 
     /// Comma-separated list of cron jobs: "cron_expr=task" pairs
     /// e.g. "0 9 * * *=Good morning report"
@@ -225,6 +241,25 @@ async fn main() -> Result<()> {
 
     if cli.webhook_port > 0 {
         let platform: Arc<dyn PlatformAdapter> = Arc::new(WebhookAdapter::new(cli.webhook_port));
+        start_platform(platform, agent.load_full(), sessions.clone()).await?;
+    }
+
+    if let (Some(bot_token), Some(app_token)) = (&cli.slack_bot_token, &cli.slack_app_token) {
+        let platform: Arc<dyn PlatformAdapter> =
+            Arc::new(SlackAdapter::new(bot_token.clone(), app_token.clone()));
+        start_platform(platform, agent.load_full(), sessions.clone()).await?;
+    }
+
+    if let (Some(homeserver), Some(user), Some(password)) = (
+        &cli.matrix_homeserver,
+        &cli.matrix_user,
+        &cli.matrix_password,
+    ) {
+        let platform: Arc<dyn PlatformAdapter> = Arc::new(MatrixAdapter::new(
+            homeserver.clone(),
+            user.clone(),
+            password.clone(),
+        ));
         start_platform(platform, agent.load_full(), sessions.clone()).await?;
     }
 

--- a/crates/garudust-platforms/Cargo.toml
+++ b/crates/garudust-platforms/Cargo.toml
@@ -8,7 +8,9 @@ default  = ["telegram", "webhook"]
 telegram = ["dep:teloxide"]
 discord  = ["dep:serenity"]
 webhook  = ["dep:axum"]
-all      = ["telegram", "discord", "webhook"]
+slack    = ["dep:tokio-tungstenite"]
+matrix   = ["dep:matrix-sdk"]
+all      = ["telegram", "discord", "webhook", "slack", "matrix"]
 
 [dependencies]
 garudust-core  = { path = "../garudust-core" }
@@ -22,6 +24,8 @@ anyhow         = { workspace = true }
 thiserror      = { workspace = true }
 futures        = { workspace = true }
 reqwest        = { workspace = true }
-axum           = { workspace = true, optional = true }
-teloxide       = { workspace = true, optional = true }
-serenity       = { workspace = true, optional = true }
+axum              = { workspace = true, optional = true }
+teloxide          = { workspace = true, optional = true }
+serenity          = { workspace = true, optional = true }
+tokio-tungstenite = { workspace = true, optional = true }
+matrix-sdk        = { workspace = true, optional = true }

--- a/crates/garudust-platforms/src/lib.rs
+++ b/crates/garudust-platforms/src/lib.rs
@@ -6,3 +6,9 @@ pub mod discord;
 
 #[cfg(feature = "webhook")]
 pub mod webhook;
+
+#[cfg(feature = "slack")]
+pub mod slack;
+
+#[cfg(feature = "matrix")]
+pub mod matrix;

--- a/crates/garudust-platforms/src/matrix.rs
+++ b/crates/garudust-platforms/src/matrix.rs
@@ -1,0 +1,142 @@
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use garudust_core::{
+    error::PlatformError,
+    platform::{MessageHandler, PlatformAdapter},
+    types::{ChannelId, InboundMessage, OutboundMessage},
+};
+use matrix_sdk::{
+    config::SyncSettings,
+    room::Room,
+    ruma::{
+        events::room::message::{
+            MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
+        },
+        RoomId,
+    },
+    Client,
+};
+use tokio::sync::OnceCell;
+
+pub struct MatrixAdapter {
+    homeserver: String,
+    username: String,
+    password: String,
+    client: Arc<OnceCell<Client>>,
+}
+
+impl MatrixAdapter {
+    pub fn new(homeserver: String, username: String, password: String) -> Self {
+        Self {
+            homeserver,
+            username,
+            password,
+            client: Arc::new(OnceCell::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl PlatformAdapter for MatrixAdapter {
+    fn name(&self) -> &'static str {
+        "matrix"
+    }
+
+    async fn start(&self, handler: Arc<dyn MessageHandler>) -> Result<(), PlatformError> {
+        let client = Client::builder()
+            .homeserver_url(&self.homeserver)
+            .build()
+            .await
+            .map_err(|e| PlatformError::Connection(e.to_string()))?;
+
+        client
+            .matrix_auth()
+            .login_username(&self.username, &self.password)
+            .initial_device_display_name("Garudust")
+            .send()
+            .await
+            .map_err(|_| PlatformError::Auth)?;
+
+        tracing::info!("Matrix logged in as {}", self.username);
+
+        // Store client for send_message
+        let _ = self.client.set(client.clone());
+
+        // Filter out our own messages
+        let bot_user_id = client.user_id().map(|id| id.to_owned());
+
+        client.add_event_handler(move |ev: OriginalSyncRoomMessageEvent, _room: Room| {
+            let handler = handler.clone();
+            let bot_uid = bot_user_id.clone();
+            async move {
+                if bot_uid.as_ref().is_some_and(|id| id == &ev.sender) {
+                    return;
+                }
+                let MessageType::Text(text_content) = ev.content.msgtype else {
+                    return;
+                };
+                let room_id = _room.room_id().to_string();
+                let inbound = InboundMessage {
+                    channel: ChannelId {
+                        platform: "matrix".into(),
+                        chat_id: room_id.clone(),
+                        thread_id: None,
+                    },
+                    user_id: ev.sender.to_string(),
+                    user_name: ev.sender.localpart().to_string(),
+                    text: text_content.body,
+                    session_key: format!("matrix:{room_id}"),
+                };
+                let _ = handler.handle(inbound).await;
+            }
+        });
+
+        // Long-poll sync loop in background
+        tokio::spawn(async move {
+            if let Err(e) = client.sync(SyncSettings::default()).await {
+                tracing::error!("Matrix sync error: {e}");
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        channel: &ChannelId,
+        message: OutboundMessage,
+    ) -> Result<(), PlatformError> {
+        let client = self
+            .client
+            .get()
+            .ok_or_else(|| PlatformError::Send("Matrix not started".into()))?;
+
+        let room_id = RoomId::parse(&channel.chat_id)
+            .map_err(|e| PlatformError::Send(format!("invalid room id: {e}")))?;
+
+        let room = client
+            .get_room(&room_id)
+            .ok_or_else(|| PlatformError::Send(format!("not in room {}", channel.chat_id)))?;
+
+        room.send(RoomMessageEventContent::text_plain(message.text))
+            .await
+            .map_err(|e: matrix_sdk::Error| PlatformError::Send(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn send_stream(
+        &self,
+        channel: &ChannelId,
+        mut stream: Pin<Box<dyn Stream<Item = String> + Send>>,
+    ) -> Result<(), PlatformError> {
+        let mut buf = String::new();
+        while let Some(chunk) = stream.next().await {
+            buf.push_str(&chunk);
+        }
+        self.send_message(channel, OutboundMessage::text(buf)).await
+    }
+}

--- a/crates/garudust-platforms/src/matrix.rs
+++ b/crates/garudust-platforms/src/matrix.rs
@@ -66,7 +66,7 @@ impl PlatformAdapter for MatrixAdapter {
         let _ = self.client.set(client.clone());
 
         // Filter out our own messages
-        let bot_user_id = client.user_id().map(|id| id.to_owned());
+        let bot_user_id = client.user_id().map(std::borrow::ToOwned::to_owned);
 
         client.add_event_handler(move |ev: OriginalSyncRoomMessageEvent, _room: Room| {
             let handler = handler.clone();

--- a/crates/garudust-platforms/src/slack.rs
+++ b/crates/garudust-platforms/src/slack.rs
@@ -1,0 +1,197 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::{SinkExt, Stream, StreamExt};
+use garudust_core::{
+    error::PlatformError,
+    platform::{MessageHandler, PlatformAdapter},
+    types::{ChannelId, InboundMessage, OutboundMessage},
+};
+use serde::Deserialize;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+pub struct SlackAdapter {
+    bot_token: String,
+    app_token: String,
+}
+
+impl SlackAdapter {
+    pub fn new(bot_token: String, app_token: String) -> Self {
+        Self {
+            bot_token,
+            app_token,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Envelope {
+    envelope_id: Option<String>,
+    #[serde(rename = "type")]
+    kind: String,
+    payload: Option<EventPayload>,
+}
+
+#[derive(Deserialize)]
+struct EventPayload {
+    event: Option<SlackEvent>,
+}
+
+#[derive(Deserialize)]
+struct SlackEvent {
+    #[serde(rename = "type")]
+    kind: String,
+    text: Option<String>,
+    user: Option<String>,
+    channel: Option<String>,
+    subtype: Option<String>,
+    bot_id: Option<String>,
+}
+
+async fn open_connection(app_token: &str) -> Result<String, PlatformError> {
+    let resp: serde_json::Value = reqwest::Client::new()
+        .post("https://slack.com/api/apps.connections.open")
+        .header("Authorization", format!("Bearer {app_token}"))
+        .header("Content-Length", "0")
+        .send()
+        .await
+        .map_err(|e| PlatformError::Connection(e.to_string()))?
+        .json()
+        .await
+        .map_err(|e| PlatformError::Connection(e.to_string()))?;
+
+    if resp["ok"].as_bool() != Some(true) {
+        return Err(PlatformError::Auth);
+    }
+    resp["url"]
+        .as_str()
+        .map(String::from)
+        .ok_or_else(|| PlatformError::Connection("no wss url in response".into()))
+}
+
+async fn post_message(bot_token: &str, channel: &str, text: &str) -> Result<(), PlatformError> {
+    let resp: serde_json::Value = reqwest::Client::new()
+        .post("https://slack.com/api/chat.postMessage")
+        .header("Authorization", format!("Bearer {bot_token}"))
+        .json(&serde_json::json!({ "channel": channel, "text": text }))
+        .send()
+        .await
+        .map_err(|e| PlatformError::Send(e.to_string()))?
+        .json()
+        .await
+        .map_err(|e| PlatformError::Send(e.to_string()))?;
+
+    if resp["ok"].as_bool() != Some(true) {
+        return Err(PlatformError::Send(
+            resp["error"].as_str().unwrap_or("unknown").to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn socket_loop(wss_url: &str, handler: Arc<dyn MessageHandler>) {
+    let Ok((ws, _)) = connect_async(wss_url).await else {
+        tracing::warn!("Slack: WebSocket connect failed");
+        return;
+    };
+    let (mut write, mut read) = ws.split();
+
+    while let Some(Ok(msg)) = read.next().await {
+        let text = match msg {
+            Message::Text(t) => t,
+            Message::Close(_) => break,
+            _ => continue,
+        };
+
+        let Ok(env) = serde_json::from_str::<Envelope>(&text) else {
+            continue;
+        };
+
+        // Acknowledge every envelope immediately
+        if let Some(eid) = &env.envelope_id {
+            let ack = format!(r#"{{"envelope_id":"{eid}"}}"#);
+            let _ = write.send(Message::Text(ack.into())).await;
+        }
+
+        if env.kind != "events_api" {
+            continue;
+        }
+
+        let Some(event) = env.payload.and_then(|p| p.event) else {
+            continue;
+        };
+
+        if event.kind != "message" || event.subtype.is_some() || event.bot_id.is_some() {
+            continue;
+        }
+
+        if let (Some(text), Some(user), Some(channel)) = (event.text, event.user, event.channel) {
+            let inbound = InboundMessage {
+                channel: ChannelId {
+                    platform: "slack".into(),
+                    chat_id: channel.clone(),
+                    thread_id: None,
+                },
+                user_id: user.clone(),
+                user_name: user,
+                text,
+                session_key: format!("slack:{channel}"),
+            };
+            let h = handler.clone();
+            tokio::spawn(async move {
+                let _ = h.handle(inbound).await;
+            });
+        }
+    }
+}
+
+#[async_trait]
+impl PlatformAdapter for SlackAdapter {
+    fn name(&self) -> &'static str {
+        "slack"
+    }
+
+    async fn start(&self, handler: Arc<dyn MessageHandler>) -> Result<(), PlatformError> {
+        let app_token = self.app_token.clone();
+
+        tokio::spawn(async move {
+            loop {
+                match open_connection(&app_token).await {
+                    Ok(url) => {
+                        tracing::info!("Slack Socket Mode connected");
+                        socket_loop(&url, handler.clone()).await;
+                        tracing::warn!("Slack socket disconnected, reconnecting in 3 s");
+                    }
+                    Err(e) => {
+                        tracing::error!("Slack connection error: {e}");
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        channel: &ChannelId,
+        message: OutboundMessage,
+    ) -> Result<(), PlatformError> {
+        post_message(&self.bot_token, &channel.chat_id, &message.text).await
+    }
+
+    async fn send_stream(
+        &self,
+        channel: &ChannelId,
+        mut stream: Pin<Box<dyn Stream<Item = String> + Send>>,
+    ) -> Result<(), PlatformError> {
+        let mut buf = String::new();
+        while let Some(chunk) = stream.next().await {
+            buf.push_str(&chunk);
+        }
+        self.send_message(channel, OutboundMessage::text(buf)).await
+    }
+}

--- a/crates/garudust-platforms/src/slack.rs
+++ b/crates/garudust-platforms/src/slack.rs
@@ -27,7 +27,7 @@ impl SlackAdapter {
 }
 
 #[derive(Deserialize)]
-struct Envelope {
+struct SlackEnvelope {
     envelope_id: Option<String>,
     #[serde(rename = "type")]
     kind: String,
@@ -105,14 +105,14 @@ async fn socket_loop(wss_url: &str, handler: Arc<dyn MessageHandler>) {
             _ => continue,
         };
 
-        let Ok(env) = serde_json::from_str::<Envelope>(&text) else {
+        let Ok(env) = serde_json::from_str::<SlackEnvelope>(&text) else {
             continue;
         };
 
         // Acknowledge every envelope immediately
         if let Some(eid) = &env.envelope_id {
             let ack = format!(r#"{{"envelope_id":"{eid}"}}"#);
-            let _ = write.send(Message::Text(ack.into())).await;
+            let _ = write.send(Message::Text(ack)).await;
         }
 
         if env.kind != "events_api" {


### PR DESCRIPTION
## Summary

Adds two new platform adapters, completing the full roadmap.

### Slack (Socket Mode)
- Connects via WebSocket Socket Mode — no public webhook URL needed
- Acks every Slack envelope immediately over WebSocket, then dispatches to the agent async
- Filters bot messages (`bot_id`, `subtype`) to prevent echo loops
- Auto-reconnects on disconnect with 3 s backoff
- Replies via `chat.postMessage` REST API

**Required env vars:**
```
SLACK_BOT_TOKEN=xoxb-...   # Bot OAuth token (chat:write scope)
SLACK_APP_TOKEN=xapp-...   # App-level token (connections:write scope)
```

### Matrix
- Logs in with username/password via `matrix_auth().login_username()`
- Filters the bot's own messages to avoid echo loops
- Runs `client.sync()` in a background task (long-poll event delivery)
- Replies via `room.send(RoomMessageEventContent::text_plain(...))`

**Required env vars:**
```
MATRIX_HOMESERVER=https://matrix.org
MATRIX_USER=@yourbot:matrix.org
MATRIX_PASSWORD=secret
```

## Architecture note

Both adapters follow the same pattern as Telegram/Discord: implement `PlatformAdapter`, gated behind a Cargo feature (`slack` / `matrix`). `garudust-server` enables `features = ["all"]`.

## Test plan

- [x] `cargo build --workspace` passes
- [x] CI clippy + fmt pass
- [ ] Slack: send a DM to the bot → agent replies
- [ ] Slack: adapter reconnects after intentional disconnect
- [ ] Matrix: send a message in a joined room → agent replies
- [ ] Matrix: bot does not echo its own replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)