### PR TITLE
chore: repo hygiene — issue templates, PR template, SECURITY.md, .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# ── LLM Provider (set exactly one) ───────────────────────────────────────────
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENROUTER_API_KEY=sk-or-...
+
+# ── Security ──────────────────────────────────────────────────────────────────
+# Bearer token required on /chat* endpoints (highly recommended in production)
+# GARUDUST_API_KEY=change-me
+
+# Command approval: auto | smart (default) | deny
+# GARUDUST_APPROVAL_MODE=smart
+
+# Per-IP rate limit in requests/minute (disabled by default)
+# GARUDUST_RATE_LIMIT=60
+
+# ── Agent ─────────────────────────────────────────────────────────────────────
+# GARUDUST_MODEL=anthropic/claude-sonnet-4-6
+# GARUDUST_PORT=3000
+# GARUDUST_WEBHOOK_PORT=3001
+
+# ── Optional tools ────────────────────────────────────────────────────────────
+# BRAVE_SEARCH_API_KEY=BSA...
+
+# ── Platform adapters (set the ones you need) ─────────────────────────────────
+# TELEGRAM_TOKEN=123456:ABC...
+
+# DISCORD_TOKEN=Bot_...
+
+# SLACK_BOT_TOKEN=xoxb-...
+# SLACK_APP_TOKEN=xapp-...
+
+# MATRIX_HOMESERVER=https://matrix.org
+# MATRIX_USER=@yourbot:matrix.org
+# MATRIX_PASSWORD=secret
+
+# ── AWS Bedrock ───────────────────────────────────────────────────────────────
+# AWS_ACCESS_KEY_ID=...
+# AWS_SECRET_ACCESS_KEY=...
+# AWS_DEFAULT_REGION=us-east-1
+
+# ── Cron ──────────────────────────────────────────────────────────────────────
+# GARUDUST_CRON_JOBS="0 9 * * *=Write a morning briefing and save to ~/briefing.md"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+# RUST_LOG=info

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Something is broken or behaving unexpectedly
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as possible.
+
+  - type: input
+    id: version
+    attributes:
+      label: Garudust version
+      description: Run `garudust --version` or `garudust-server --version`
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: LLM provider
+      options:
+        - Anthropic
+        - OpenRouter
+        - AWS Bedrock
+        - OpenAI-compatible (custom)
+        - Other / not applicable
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: How are you running Garudust?
+      options:
+        - CLI / TUI (garudust)
+        - Headless server (garudust-server)
+        - Docker
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `garudust-server --anthropic-key ...`
+        2. Send `POST /chat` with `{"message": "..."}`
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Run with `RUST_LOG=debug` and paste relevant output. **Remove any API keys before pasting.**
+      render: text
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / Architecture
+      placeholder: "macOS 14 (arm64), Ubuntu 22.04 (x86_64), ..."
+    validations:
+      required: true
+
+  - type: input
+    id: rust
+    attributes:
+      label: Rust toolchain version
+      description: Run `rustc --version`
+      placeholder: "rustc 1.82.0"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/ninenox/garudust/discussions
+    about: Ask questions and discuss ideas in GitHub Discussions
+  - name: Security Vulnerability
+    url: https://github.com/ninenox/garudust/security/advisories/new
+    about: Report a security issue privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a new tool, platform adapter, transport, or other improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a request, please check the [existing issues](https://github.com/ninenox/garudust/issues) to avoid duplicates.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this affect?
+      options:
+        - New tool (garudust-tools)
+        - New platform adapter (garudust-platforms)
+        - New LLM transport (garudust-transport)
+        - CLI / TUI (bin/garudust)
+        - HTTP gateway (garudust-gateway)
+        - Agent behaviour / run loop
+        - Memory / session persistence
+        - Security
+        - Docker / deployment
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point. "I want to..." or "Currently it is hard to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should it work? Feel free to sketch an API, config snippet, or rough design.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds exist today? Why are they insufficient?
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Are you willing to implement this?
+      options:
+        - label: Yes, I can open a PR for this
+        - label: I can help review/test but not implement
+        - label: I'm just requesting — happy for someone else to pick it up

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR do and why? 1-3 bullet points. -->
+
+-
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (alters existing API or behaviour)
+- [ ] Documentation / comments only
+- [ ] CI / tooling / chore
+
+## Checklist
+
+- [ ] `cargo check --workspace --all-targets` passes
+- [ ] `cargo clippy --workspace --all-targets -- -W clippy::all -W clippy::pedantic` passes (same flags as CI)
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] No API keys, tokens, or secrets committed (`git diff HEAD | grep -iE '(api.?key|secret|token|bearer|sk-)'`)
+- [ ] New tools registered in `bin/garudust/src/main.rs` and `bin/garudust-server/src/main.rs`
+- [ ] New platform adapters added behind a feature flag in `garudust-platforms/Cargo.toml`
+- [ ] README updated if user-facing behaviour changed
+
+## Testing
+
+<!-- How did you verify this works? Manual steps, test output, etc. -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,25 @@
+# Build output
 /target
+
+# Secrets — never commit real credentials
 .env
+.env.local
+.env.*.local
+
+# SQLite state files
 *.db
 *.db-shm
 *.db-wal
+
+# macOS
+.DS_Store
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# Garudust user data (kept local, not in repo)
+# ~/.garudust/ is outside the repo — this covers any accidental symlinks
+state.db
+config.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,16 +29,16 @@ cargo fmt --all -- --check
 
 | Crate / Binary | Purpose |
 |----------------|---------|
-| `crates/garudust-core` | Shared types, traits (`Tool`, `ProviderTransport`, `PlatformAdapter`, `MemoryStore`), config, errors |
-| `crates/garudust-transport` | LLM provider implementations — Anthropic, OpenAI-compatible (OpenRouter, etc.) |
-| `crates/garudust-tools` | Built-in tools: `read_file`, `write_file`, `terminal`, `web_fetch`, `web_search`, `memory`, `skills_list`, `skill_view` |
+| `crates/garudust-core` | Shared types, traits (`Tool`, `ProviderTransport`, `PlatformAdapter`, `MemoryStore`), config, `SecurityConfig`, `net_guard` (SSRF) |
+| `crates/garudust-transport` | LLM provider implementations — Anthropic, OpenAI-compatible (OpenRouter, etc.), AWS Bedrock, Codex |
+| `crates/garudust-tools` | Built-in tools: `read_file`, `write_file`, `terminal`, `web_fetch`, `web_search`, `browser`, `memory`, `delegate_task`, `skills_list`, `skill_view` |
 | `crates/garudust-memory` | Persistence: `FileMemoryStore` (markdown files) + `SessionDb` (SQLite + FTS5) |
-| `crates/garudust-agent` | Agent run loop, context compression, session persistence, `AutoApprover` / `DenyApprover` |
-| `crates/garudust-platforms` | Platform adapters: Telegram, Discord, Webhook |
+| `crates/garudust-agent` | Agent run loop, context compression, session persistence, `AutoApprover` / `SmartApprover` / `DenyApprover` |
+| `crates/garudust-platforms` | Platform adapters: Telegram, Discord, Slack (Socket Mode), Matrix, Webhook |
 | `crates/garudust-cron` | Cron scheduler — wraps `tokio-cron-scheduler`, spawns agent on schedule |
-| `crates/garudust-gateway` | HTTP gateway — `GatewayHandler`, `SessionRegistry`, `AppState`, `/health` + `/chat` routes |
+| `crates/garudust-gateway` | HTTP gateway — Bearer auth middleware, rate limiting, `GatewayHandler`, `/health` + `/chat*` routes |
 | `bin/garudust` | CLI binary: TUI chat, `setup`, `config show/set`, `doctor` |
-| `bin/garudust-server` | Headless server: Telegram + Discord + Webhook + HTTP API + Cron |
+| `bin/garudust-server` | Headless server: all platform adapters + HTTP API + Cron in one process |
 
 Each crate has a single focused responsibility. Keep those boundaries clean.
 
@@ -201,11 +201,15 @@ Recommended scope keys: `agent`, `tools`, `transport`, `memory`, `platforms`, `g
 
 Before every commit, verify:
 
-- No `.env` files are staged
+- No `.env` files are staged (`git status` should not show `.env`)
 - No raw API keys or tokens in code, tests, or fixtures
 - `git diff --cached | grep -iE '(api[_-]?key|secret|token|bearer|sk-)'` returns nothing
 
 `~/.garudust/.env` and `~/.garudust/config.yaml` are user-local and git-ignored by default.
+
+## Security
+
+Security-sensitive changes (new tool with network access, auth logic, file I/O) should be accompanied by a note in the PR explaining the threat model. See [SECURITY.md](SECURITY.md) for the project's security policy and how to report vulnerabilities privately.
 
 ## CI
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest commit on `main` is actively supported. There are no versioned releases with long-term security backports at this time.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report security issues privately through one of these channels:
+
+1. **GitHub Security Advisories (preferred)** — [Open a private advisory](https://github.com/ninenox/garudust/security/advisories/new). This keeps the report confidential until a fix is ready.
+2. **Email** — `nashnox15@gmail.com` with subject `[SECURITY] Garudust — <short description>`.
+
+### What to include
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce (command, config, request payload, etc.)
+- The version / commit you tested against
+- Any suggested fix or mitigation (optional but appreciated)
+
+### Response timeline
+
+| Milestone | Target |
+|-----------|--------|
+| Acknowledgement | Within 72 hours |
+| Initial assessment | Within 7 days |
+| Fix / advisory published | Depends on severity and complexity |
+
+## Threat Model
+
+Garudust is designed for **self-hosted, trusted-network deployment**. Key assumptions:
+
+- The HTTP gateway (`/chat*`) should be protected by `GARUDUST_API_KEY` before exposing it to the internet.
+- The `terminal` tool executes shell commands — do not expose Garudust to untrusted users without setting `--approval-mode deny` or `smart`.
+- Platform adapter credentials (Telegram token, Slack tokens, etc.) grant the agent access to those platforms as a bot. Treat them like API keys.
+- MCP server subprocesses are launched with the agent's full OS permissions. Only connect trusted MCP servers.
+
+## Security Controls
+
+| Control | Configuration |
+|---------|---------------|
+| HTTP authentication | `GARUDUST_API_KEY=<token>` |
+| Command approval | `GARUDUST_APPROVAL_MODE=smart` (default) or `deny` |
+| Per-IP rate limiting | `GARUDUST_RATE_LIMIT=60` (req/min, opt-in) |
+| SSRF protection | Built-in — blocks private IPs and cloud metadata endpoints |
+| File path sandboxing | Reads/writes restricted to cwd and home directory |
+| Secrets isolation | `.env` values never written to process environment |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,37 @@ services:
     ports:
       - "3000:3000"
     environment:
-      # Set at least one of these:
+      # LLM provider — set at least one
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      # Optional overrides
+
+      # Security — strongly recommended in production
+      GARUDUST_API_KEY: ${GARUDUST_API_KEY:-}
+      GARUDUST_APPROVAL_MODE: ${GARUDUST_APPROVAL_MODE:-smart}
+      GARUDUST_RATE_LIMIT: ${GARUDUST_RATE_LIMIT:-}
+
+      # Agent settings
       GARUDUST_MODEL: ${GARUDUST_MODEL:-}
       GARUDUST_PORT: "3000"
       RUST_LOG: ${RUST_LOG:-info}
+
+      # Platform adapters (uncomment / set as needed)
+      TELEGRAM_TOKEN: ${TELEGRAM_TOKEN:-}
+      DISCORD_TOKEN: ${DISCORD_TOKEN:-}
+      SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
+      SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:-}
+      MATRIX_HOMESERVER: ${MATRIX_HOMESERVER:-}
+      MATRIX_USER: ${MATRIX_USER:-}
+      MATRIX_PASSWORD: ${MATRIX_PASSWORD:-}
     volumes:
       - garudust-data:/root/.garudust
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
   garudust-data:


### PR DESCRIPTION
## Summary

- Add structured GitHub issue templates (bug report + feature request with YAML forms)
- Disable blank issues; link to Discussions and Security Advisories instead
- Add PR checklist template
- Add `SECURITY.md` with private disclosure policy, threat model, and controls table
- Add `.env.example` with every supported env var and inline comments
- Update `docker-compose.yml` with security env vars + healthcheck
- Expand `.gitignore` (`.env.local`, `.DS_Store`, IDE dirs)
- Update `CONTRIBUTING.md` crate table + add Security section

## Type of change

- [x] Documentation / comments only
- [x] CI / tooling / chore

## Checklist

- [x] No code changes — no clippy / fmt issues possible
- [x] No API keys or secrets committed
- [x] README not affected (these are repo-level files only)