### PR TITLE
feat(cli): add Brave Search API key prompt in Full setup mode

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,11 +1,15 @@
 name: Claude PR Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 jobs:
   review:
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -15,9 +19,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 1
 
+      - name: Get PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBER=$(gh api "repos/$REPO/pulls" \
+            --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" | head -1)
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
       - uses: anthropics/claude-code-action@v1
+        if: steps.pr.outputs.number != ''
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |
@@ -33,7 +50,7 @@ jobs:
               }
             }
           prompt: |
-            Review Pull Request #${{ github.event.pull_request.number }} in this repository.
+            Review Pull Request #${{ steps.pr.outputs.number }} in this repository.
 
             ตรวจสอบไฟล์ที่เปลี่ยนแปลงใน PR นี้ในด้าน:
             - Code quality และความถูกต้อง
@@ -51,10 +68,10 @@ jobs:
             สรุปกระชับ ระบุเฉพาะประเด็นสำคัญ ถ้าไม่พบปัญหาให้บอกว่า LGTM
 
       - name: Post review as PR comment
-        if: always()
+        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           GH_REPO: ${{ github.repository }}
         run: |
           python3 - << 'PYEOF'

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   review:
+    # Only review when all CI checks pass — avoids reviewing code that still
+    # has lint/format errors and wastes tokens on already-known problems.
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
@@ -31,6 +33,9 @@ jobs:
         run: |
           PR_NUMBER=$(gh api "repos/$REPO/pulls" \
             --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" | head -1)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::warning::No open PR found for SHA $HEAD_SHA — skipping review"
+          fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - uses: anthropics/claude-code-action@v1

--- a/bin/garudust/src/setup.rs
+++ b/bin/garudust/src/setup.rs
@@ -159,10 +159,12 @@ pub async fn run() -> anyhow::Result<()> {
     println!();
 
     // ── Doctor ────────────────────────────────────────────────────────────────
-    if let Some((_, key)) = env_vars
-        .iter()
-        .find(|(v, _)| matches!(*v, "ANTHROPIC_API_KEY" | "OPENROUTER_API_KEY" | "VLLM_API_KEY"))
-    {
+    if let Some((_, key)) = env_vars.iter().find(|(v, _)| {
+        matches!(
+            *v,
+            "ANTHROPIC_API_KEY" | "OPENROUTER_API_KEY" | "VLLM_API_KEY"
+        )
+    }) {
         config.api_key = Some(key.clone());
     }
     super::doctor::run(&config).await;

--- a/bin/garudust/src/setup.rs
+++ b/bin/garudust/src/setup.rs
@@ -159,8 +159,10 @@ pub async fn run() -> anyhow::Result<()> {
     println!();
 
     // ── Doctor ────────────────────────────────────────────────────────────────
-    const PROVIDER_KEY_VARS: &[&str] = &["ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "VLLM_API_KEY"];
-    if let Some((_, key)) = env_vars.iter().find(|(v, _)| PROVIDER_KEY_VARS.contains(v)) {
+    if let Some((_, key)) = env_vars
+        .iter()
+        .find(|(v, _)| matches!(*v, "ANTHROPIC_API_KEY" | "OPENROUTER_API_KEY" | "VLLM_API_KEY"))
+    {
         config.api_key = Some(key.clone());
     }
     super::doctor::run(&config).await;

--- a/bin/garudust/src/setup.rs
+++ b/bin/garudust/src/setup.rs
@@ -109,6 +109,19 @@ pub async fn run() -> anyhow::Result<()> {
 
     // ── Platform adapters (Full mode) ─────────────────────────────────────────
     if full {
+        println!("Optional Tools (Enter to skip each):");
+        let tool_fields: &[(&str, &str)] = &[(
+            "Brave Search API key (web_search tool)",
+            "BRAVE_SEARCH_API_KEY",
+        )];
+        for (label, var) in tool_fields {
+            let val = prompt(label, Some(""));
+            if !val.is_empty() {
+                env_vars.push((var, val));
+            }
+        }
+        println!();
+
         println!("Platform Adapters (Enter to skip each):");
         let platform_fields: &[(&str, &str)] = &[
             ("Telegram bot token", "TELEGRAM_TOKEN"),

--- a/bin/garudust/src/setup.rs
+++ b/bin/garudust/src/setup.rs
@@ -159,7 +159,8 @@ pub async fn run() -> anyhow::Result<()> {
     println!();
 
     // ── Doctor ────────────────────────────────────────────────────────────────
-    if let Some((_, key)) = env_vars.iter().find(|(v, _)| v.ends_with("API_KEY")) {
+    const PROVIDER_KEY_VARS: &[&str] = &["ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "VLLM_API_KEY"];
+    if let Some((_, key)) = env_vars.iter().find(|(v, _)| PROVIDER_KEY_VARS.contains(v)) {
         config.api_key = Some(key.clone());
     }
     super::doctor::run(&config).await;

--- a/bin/garudust/src/setup.rs
+++ b/bin/garudust/src/setup.rs
@@ -107,7 +107,7 @@ pub async fn run() -> anyhow::Result<()> {
     };
     println!();
 
-    // ── Platform adapters (Full mode) ─────────────────────────────────────────
+    // ── Optional tools + platform adapters (Full mode) ───────────────────────
     if full {
         println!("Optional Tools (Enter to skip each):");
         let tool_fields: &[(&str, &str)] = &[(


### PR DESCRIPTION
## Summary

- เพิ่ม `BRAVE_SEARCH_API_KEY` เป็น optional prompt ใน Full setup mode
- ถาม tool credentials ก่อน platform tokens เพื่อให้ลำดับสมเหตุสมผล

## Type of change

- [x] New feature (non-breaking)

## Checklist

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo clippy --workspace --all-targets` passes
- [x] `cargo fmt --all -- --check` passes
- [x] No API keys, tokens, or secrets committed