### PR TITLE
fix: preserve tool call id/name when streamed before arguments (Qwen3/vLLM)

### DIFF
--- a/crates/garudust-transport/src/chat_completions.rs
+++ b/crates/garudust-transport/src/chat_completions.rs
@@ -336,23 +336,29 @@ impl ProviderTransport for ChatCompletionsTransport {
                                 tc_acc[index].1 = name.to_string();
                             }
                             if let Some(args) = tc["function"]["arguments"].as_str() {
-                                let entry = &mut tc_acc[index];
-                                let is_first = entry.0.is_empty() && entry.1.is_empty();
+                                // is_first_args: true the first time we receive arguments for
+                                // this tool call. Some providers (e.g. Qwen3/vLLM) send id +
+                                // name in a separate earlier chunk with no arguments, so we
+                                // cannot use `entry.0.is_empty()` here — that would always be
+                                // false by the time args arrive, causing id/name to be dropped.
+                                let is_first_args = tc_acc[index].2.is_empty();
+                                let acc_id = tc_acc[index].0.clone();
+                                let acc_name = tc_acc[index].1.clone();
+                                tc_acc[index].2.push_str(args);
                                 yield StreamChunk::ToolCallDelta {
                                     index,
-                                    id: if is_first {
-                                        tc["id"].as_str().map(str::to_string)
+                                    id: if is_first_args && !acc_id.is_empty() {
+                                        Some(acc_id)
                                     } else {
                                         None
                                     },
-                                    name: if is_first {
-                                        tc["function"]["name"].as_str().map(str::to_string)
+                                    name: if is_first_args && !acc_name.is_empty() {
+                                        Some(acc_name)
                                     } else {
                                         None
                                     },
                                     args_delta: args.to_string(),
                                 };
-                                entry.2.push_str(args);
                             }
                         }
                     }
@@ -430,5 +436,38 @@ mod tests {
         assert_eq!(json.len(), 1);
         let tcs = json[0]["tool_calls"].as_array().unwrap();
         assert_eq!(tcs[0]["function"]["name"], "read_file");
+    }
+
+    /// Qwen3/vLLM streams id+name in a separate chunk before arguments.
+    /// Verify that the accumulator correctly propagates id and name to the
+    /// first ToolCallDelta that carries arguments.
+    #[test]
+    fn streaming_id_name_before_args() {
+        // Simulate what the accumulator logic does for the split-chunk pattern
+        let mut tc_acc: Vec<(String, String, String)> = Vec::new();
+
+        // Chunk 1: id + name, no args (Qwen3 pattern)
+        let index = 0usize;
+        while tc_acc.len() <= index {
+            tc_acc.push((String::new(), String::new(), String::new()));
+        }
+        tc_acc[index].0 = "call_abc".to_string();
+        tc_acc[index].1 = "web_search".to_string();
+        // no args yet — no ToolCallDelta emitted
+
+        // Chunk 2: args arrive, id/name absent in this chunk
+        let args = r#"{"query":"gold price"}"#;
+        let is_first_args = tc_acc[index].2.is_empty();
+        let acc_id = tc_acc[index].0.clone();
+        let acc_name = tc_acc[index].1.clone();
+        tc_acc[index].2.push_str(args);
+
+        assert!(is_first_args, "should be first args chunk");
+        assert_eq!(acc_id, "call_abc", "id must survive split-chunk pattern");
+        assert_eq!(
+            acc_name, "web_search",
+            "name must survive split-chunk pattern"
+        );
+        assert_eq!(tc_acc[index].2, args);
     }
 }


### PR DESCRIPTION
## Root Cause

Qwen3 via vLLM streams tool calls in **two separate SSE chunks**:
1. Chunk with `id` + `name` (no `arguments`)
2. Subsequent chunks with `arguments` only

The old code checked `is_first = entry.0.is_empty() && entry.1.is_empty()` at the moment `arguments` arrived — but by then `id` and `name` had already been stored in `tc_acc`, so `is_first` was always `false`. The `ToolCallDelta` was emitted with `id: None` and `name: None`.

In `stream_turn` (agent.rs), tool calls with an empty `id` are filtered out:
```rust
.filter(|(id, ..)| !id.is_empty())
```
So the final `tool_calls` vec was empty → agent treated the turn as a complete response → returned an empty string.

**Symptom:** asking about gold price / anything requiring web search returned a blank reply.

## Fix

Replace `is_first` check with `entry.2.is_empty()` (first time we see args for this slot). Copy `id` and `name` from the accumulator (already populated by the earlier id/name-only chunk) rather than from the current chunk, which carries neither.

## Test

Added `streaming_id_name_before_args` unit test that simulates the split-chunk pattern and verifies the accumulator retains the correct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)