### PR TITLE
feat: Hermes-style memory nudge + Thai memory-intent trigger

### DIFF
--- a/crates/garudust-agent/src/agent.rs
+++ b/crates/garudust-agent/src/agent.rs
@@ -23,6 +23,20 @@ use tokio::sync::mpsc;
 /// Results from these tools are wrapped in XML tags to help the model
 /// distinguish untrusted data from authoritative instructions.
 const EXTERNAL_TOOLS: &[&str] = &["web_fetch", "web_search", "browser", "read_file"];
+
+/// Hermes-style nudge injected before every Nth LLM call to remind the model
+/// to persist any new facts or preferences it encountered during the task.
+const MEMORY_NUDGE: &str = "[System: You have completed several tool-use rounds in this task. \
+     If you learned any new user preferences, facts, or corrections, \
+     call save_memory now to persist them before continuing.]";
+
+/// Thai-language keywords that indicate the user wants to save something to memory.
+const THAI_MEMORY_KEYWORDS: &[&str] = &["จำ", "บันทึก", "จำไว้", "จดจำ", "จำข้อมูล", "จำให้", "เก็บไว้"];
+
+/// Returns true if `text` contains any Thai memory-intent keyword.
+fn has_thai_memory_intent(text: &str) -> bool {
+    THAI_MEMORY_KEYWORDS.iter().any(|kw| text.contains(kw))
+}
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -300,6 +314,18 @@ impl Agent {
                 },
             );
 
+        // Append English save-memory note when the user's message contains Thai
+        // memory-intent keywords so local models (e.g. Qwen3) recognise the request
+        // regardless of language.
+        let user_msg = if has_thai_memory_intent(task) {
+            format!(
+                "{user_msg}\n\n[System note: The user may be asking you to \
+                 remember something. If so, call the save_memory tool before responding.]"
+            )
+        } else {
+            user_msg
+        };
+
         let mut history: Vec<Message> =
             vec![Message::system(&system_prompt), Message::user(&user_msg)];
 
@@ -309,6 +335,15 @@ impl Agent {
         let mut iters = 0u32;
 
         loop {
+            // Hermes-style nudge: remind the model to save memory every N tool rounds.
+            // iters == 0 on the first pass (before increment), so this only fires after
+            // at least one full tool-use round has completed.
+            let nudge = self.config.nudge_interval;
+            if nudge > 0 && iters > 0 && iters.is_multiple_of(nudge) {
+                history.push(Message::user(MEMORY_NUDGE));
+                debug!(iteration = iters, "injecting memory nudge");
+            }
+
             // Compress if needed before every LLM call
             if self.config.compression.enabled && self.compressor.should_compress(&history) {
                 info!("compressing context before turn {}", iters + 1);

--- a/crates/garudust-core/src/config.rs
+++ b/crates/garudust-core/src/config.rs
@@ -58,6 +58,14 @@ pub struct AgentConfig {
     pub security: SecurityConfig,
     #[serde(default)]
     pub memory_expiry: MemoryExpiryConfig,
+    /// Inject a memory-save reminder every N tool-use iterations within a task.
+    /// 0 = disabled. Default: 5.
+    #[serde(default = "default_nudge_interval")]
+    pub nudge_interval: u32,
+}
+
+fn default_nudge_interval() -> u32 {
+    5
 }
 
 /// Per-category retention policy for memory entries.
@@ -167,6 +175,7 @@ impl Default for AgentConfig {
                 rate_limit_rpm: None,
             },
             memory_expiry: MemoryExpiryConfig::default(),
+            nudge_interval: default_nudge_interval(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Long-task nudge** (`nudge_interval`, default 5): every N tool-use iterations inside `run_inner`, inject a `[System: ...]` reminder message before the next LLM call so the model saves newly learned facts/preferences — mirrors Hermes `_memory_nudge_interval = 10`.
- **Thai memory trigger**: detect Thai save-intent keywords (`จำ`, `บันทึก`, `จำไว้`, `จดจำ`, `จำข้อมูล`, `จำให้`, `เก็บไว้`) in the user message and append an English system note, so local models (Qwen3) recognise the request regardless of input language.
- `nudge_interval: u32` added to `AgentConfig` (YAML-configurable, serde default = 5, 0 = disabled).
- Both features apply uniformly across **all platforms** (CLI one-shot, CLI TUI, Telegram, Discord, Slack, Matrix, Webhook) since they live in `run_inner`.

## Test plan

- [x] `cargo clippy --all-targets --all-features` (RUSTFLAGS="-D warnings") — clean
- [x] `cargo fmt --all` — no diff
- [ ] Manual: run one-shot task with >5 tool calls, verify nudge log line appears (`injecting memory nudge`)
- [ ] Manual: send Thai message containing `จำ` via Telegram/CLI, verify `save_memory` tool is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)