### PR TITLE
fix: register missing tools in main agent build

### DIFF
--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -217,9 +217,13 @@ async fn main() -> Result<()> {
         registry.register(WriteFile);
         registry.register(Terminal);
         registry.register(MemoryTool);
+        registry.register(UserProfileTool);
         registry.register(SessionSearch);
         registry.register(SkillsList);
         registry.register(SkillView);
+        registry.register(WriteSkill);
+        registry.register(DelegateTask);
+        registry.register(BrowserTool::new());
         let mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
         let db = SessionDb::open(&config.home_dir).ok().map(Arc::new);
         let a = Agent::new(transport, Arc::new(registry), memory, config.clone());


### PR DESCRIPTION
## Summary

- The inline registry in `main()` was missing 4 tools that `build_agent()` already had: `WriteSkill`, `DelegateTask`, `UserProfileTool`, `BrowserTool`
- This caused skill creation (`write_skill`) to be unavailable in one-shot and TUI modes — the model hallucinated success instead of actually saving the file
- Found during manual testing: `garudust "Create a skill..."` never dispatched `write_skill`

## Test plan

- [x] `cargo build --release` clean
- [x] `garudust "Use write_skill to create skill rust-check..."` → file created at `~/.garudust/skills/rust-check/SKILL.md`
- [x] `garudust "สร้าง skill daily-standup..."` (Thai) → file created correctly
- [x] `garudust "List all my skills"` → shows both created skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)