### PR TITLE
fix(security): close DNS TOCTOU/rebinding gap in SSRF protection

### DIFF
--- a/crates/garudust-core/src/net_guard.rs
+++ b/crates/garudust-core/src/net_guard.rs
@@ -67,15 +67,19 @@ pub fn is_safe_url(url: &str) -> Result<(), ToolError> {
     Ok(())
 }
 
-fn check_ip(ip: IpAddr, host: &str) -> Result<(), ToolError> {
-    let blocked = match ip {
+/// Returns `true` if the IP is private, loopback, link-local, or unspecified
+/// and must therefore be blocked to prevent SSRF.
+pub fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
         IpAddr::V4(v4) => {
             is_private_v4(v4) || v4.is_loopback() || v4.is_unspecified() || v4.is_link_local()
         }
         IpAddr::V6(v6) => is_private_v6(v6) || v6.is_loopback() || v6.is_unspecified(),
-    };
+    }
+}
 
-    if blocked {
+fn check_ip(ip: IpAddr, host: &str) -> Result<(), ToolError> {
+    if is_blocked_ip(ip) {
         return Err(ToolError::Execution(format!(
             "blocked: '{host}' resolves to a private/reserved address ({ip})"
         )));

--- a/crates/garudust-tools/src/toolsets/web.rs
+++ b/crates/garudust-tools/src/toolsets/web.rs
@@ -1,3 +1,6 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use garudust_core::{
     error::ToolError,
@@ -5,7 +8,41 @@ use garudust_core::{
     tool::{Tool, ToolContext},
     types::ToolResult,
 };
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use serde_json::json;
+
+// ─── Safe DNS resolver ────────────────────────────────────────────────────────
+
+/// Custom DNS resolver that filters out private/reserved IPs at resolution time,
+/// closing the TOCTOU gap between is_safe_url() and reqwest's actual connect.
+struct SafeResolver;
+
+impl Resolve for SafeResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let all: Vec<SocketAddr> = tokio::net::lookup_host(format!("{host}:0"))
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                .collect();
+
+            let safe: Vec<SocketAddr> = all
+                .into_iter()
+                .filter(|a| !net_guard::is_blocked_ip(a.ip()))
+                .collect();
+
+            if safe.is_empty() {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!("SSRF protection: '{host}' resolved only to private/reserved IPs"),
+                ))
+                    as Box<dyn std::error::Error + Send + Sync>);
+            }
+
+            Ok(Box::new(safe.into_iter()) as Addrs)
+        })
+    }
+}
 
 // ─── WebFetch ─────────────────────────────────────────────────────────────────
 
@@ -44,7 +81,9 @@ impl Tool for WebFetch {
 
         net_guard::is_safe_url(url)?;
 
-        let body = reqwest::get(url)
+        let body = http_client()?
+            .get(url)
+            .send()
             .await
             .map_err(|e| ToolError::Execution(e.to_string()))?
             .text()
@@ -118,6 +157,7 @@ fn http_client() -> Result<&'static reqwest::Client, ToolError> {
     let c = reqwest::Client::builder()
         .user_agent("Mozilla/5.0 (compatible; Garudust/1.0)")
         .timeout(std::time::Duration::from_secs(10))
+        .dns_resolver(Arc::new(SafeResolver))
         .build()
         .map_err(|e| ToolError::Execution(format!("HTTP client init failed: {e}")))?;
     Ok(HTTP_CLIENT.get_or_init(|| c))


### PR DESCRIPTION
## Summary

Closes #34

Previously `is_safe_url()` resolved the hostname and checked the IP **once**, but `reqwest` performed a **second** DNS resolution at connect time. An attacker controlling a DNS server could pass the first check with a public IP, then switch the record to `169.254.169.254` (cloud metadata) before reqwest connected — a classic DNS TOCTOU attack.

**Fix:** `SafeResolver` implements `reqwest::dns::Resolve` and intercepts DNS resolution *inside* reqwest. It filters every resolved IP through `is_blocked_ip()` and errors if no safe IPs remain. Since the resolution that is checked **is** the one used for connecting, there is no TOCTOU window.

**Defense-in-depth layers (both kept):**
1. `is_safe_url()` — fast early rejection of known-bad hostnames (`metadata.google.internal`, etc.) and IP literals; produces friendly error messages before any network I/O
2. `SafeResolver` — closes the TOCTOU gap atomically at the reqwest DNS layer

**Also fixed:** `WebFetch::execute` was calling `reqwest::get(url)` (bare global client with no custom resolver), bypassing the `SafeResolver` entirely. Now uses `http_client()`.

## Changes

- `crates/garudust-core/src/net_guard.rs` — export `is_blocked_ip(ip: IpAddr) -> bool` (extracted from `check_ip`)
- `crates/garudust-tools/src/toolsets/web.rs` — add `SafeResolver`, wire into `http_client()` via `.dns_resolver()`, fix `WebFetch` to use `http_client()`

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy` (with CI flags) — no errors
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p garudust-core -p garudust-tools` — 23 tests pass
- [x] Existing `net_guard` tests cover loopback, private ranges, cloud metadata hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)