### PR TITLE
feat(audit): structured INFO-level audit log for all tool calls

### DIFF
--- a/crates/garudust-tools/src/registry.rs
+++ b/crates/garudust-tools/src/registry.rs
@@ -49,29 +49,69 @@ impl ToolRegistry {
             .get(name)
             .ok_or_else(|| ToolError::NotFound(name.into()))?;
 
-        // Property-based approval gate: check what the tool IS, not what the
-        // command string looks like. Destructive tools always produce an audit
-        // entry and run through the approver regardless of which tool calls them.
+        // Property-based approval gate for destructive tools.
         if tool.is_destructive() {
             let decision = ctx.approver.approve(name, &params.to_string()).await;
             tracing::info!(
                 session_id = %ctx.session_id,
                 tool       = %name,
-                params     = %params,
+                args       = %truncate(&params.to_string(), 500),
                 approved   = %(decision != ApprovalDecision::Denied),
-                "destructive tool call"
+                "tool approval"
             );
             if decision == ApprovalDecision::Denied {
                 return Err(ToolError::ApprovalDenied);
             }
         }
 
-        tool.execute(params, ctx).await
+        tracing::info!(
+            session_id = %ctx.session_id,
+            tool       = %name,
+            args       = %truncate(&params.to_string(), 500),
+            "tool call started"
+        );
+
+        let started = tokio::time::Instant::now();
+        let result = tool.execute(params, ctx).await;
+        let duration_ms = started.elapsed().as_millis();
+
+        match &result {
+            Ok(r) => tracing::info!(
+                session_id  = %ctx.session_id,
+                tool        = %name,
+                duration_ms = duration_ms,
+                success     = true,
+                tool_error  = r.is_error,
+                "tool call completed"
+            ),
+            Err(e) => tracing::info!(
+                session_id  = %ctx.session_id,
+                tool        = %name,
+                duration_ms = duration_ms,
+                success     = false,
+                error       = %e,
+                "tool call failed"
+            ),
+        }
+
+        result
     }
 
     pub fn names(&self) -> Vec<&str> {
         self.tools.keys().map(String::as_str).collect()
     }
+}
+
+/// Truncate a string to at most `max` bytes at a UTF-8 char boundary for safe logging.
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 }
 
 impl Default for ToolRegistry {


### PR DESCRIPTION
## Summary

Closes #38

Every tool dispatch now emits structured `tracing::info!` events visible at the default `RUST_LOG=info` level:

| Event | Fields |
|---|---|
| `tool approval` | `session_id`, `tool`, `args`, `approved` — destructive tools only |
| `tool call started` | `session_id`, `tool`, `args` (≤ 500 bytes) |
| `tool call completed` | `session_id`, `tool`, `duration_ms`, `success=true`, `tool_error` |
| `tool call failed` | `session_id`, `tool`, `duration_ms`, `success=false`, `error` |

Previously only destructive tool calls were logged (no duration, no success/fail). Non-destructive calls were completely invisible at production log levels.

Args are truncated to 500 bytes at a UTF-8 char boundary to keep log lines bounded.

## Test plan

- [x] `cargo clippy` — no errors
- [x] `cargo fmt --check` — clean  
- [x] `cargo test -p garudust-tools` — 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)