### PR TITLE
fix(agent): give each sub-agent its own iteration budget

### DIFF
--- a/crates/garudust-agent/src/agent.rs
+++ b/crates/garudust-agent/src/agent.rs
@@ -144,6 +144,9 @@ pub struct Agent {
 
 impl Clone for Agent {
     fn clone(&self) -> Self {
+        // Intentionally shares the budget Arc — clone() produces an alias of the
+        // same logical agent (e.g. for the TUI's model-switch flow), not a child.
+        // Use spawn_child() when isolation is required.
         let comp_model = self
             .config
             .compression
@@ -201,6 +204,16 @@ impl Agent {
     pub fn with_session_db(mut self, db: Arc<SessionDb>) -> Self {
         self.session_db = Some(db);
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn budget_remaining(&self) -> u32 {
+        self.budget.remaining()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn consume_budget(&self) {
+        let _ = self.budget.consume();
     }
 
     pub fn spawn_child(&self) -> Self {
@@ -427,11 +440,15 @@ impl Agent {
             }
 
             // Parallel tool dispatch via tokio::join_all
-            let sub_agent: Arc<dyn SubAgentRunner> = Arc::new(self.clone());
+            // spawn_child() gives the sub-agent its own fresh budget so delegate_task
+            // iterations do not consume the parent's quota.
+            let sub_agent: Arc<dyn SubAgentRunner> = Arc::new(self.spawn_child());
             let ctx = Arc::new(ToolContext {
                 session_id: session_id.clone(),
                 agent_id: self.id.clone(),
                 iteration: iters,
+                // Tool calls themselves (web_fetch, terminal, etc.) count against
+                // the parent's budget; only delegate_task runs an isolated child.
                 budget: self.budget.clone(),
                 memory: self.memory.clone(),
                 config: self.config.clone(),

--- a/crates/garudust-agent/src/agent.rs
+++ b/crates/garudust-agent/src/agent.rs
@@ -215,7 +215,7 @@ impl Agent {
             transport: self.transport.clone(),
             tools: self.tools.clone(),
             memory: self.memory.clone(),
-            budget: self.budget.clone(),
+            budget: Arc::new(IterationBudget::new(self.config.max_iterations)),
             config: self.config.clone(),
             compressor: ContextCompressor::new(self.transport.clone(), comp_model),
             session_db: self.session_db.clone(),

--- a/crates/garudust-agent/src/tests.rs
+++ b/crates/garudust-agent/src/tests.rs
@@ -91,6 +91,10 @@ impl CommandApprover for AutoApprove {
 
 fn make_agent(reply: &str) -> Arc<Agent> {
     let config = Arc::new(AgentConfig::default());
+    make_agent_with_config(reply, config)
+}
+
+fn make_agent_with_config(reply: &str, config: Arc<AgentConfig>) -> Arc<Agent> {
     let transport = Arc::new(StaticTransport {
         reply: reply.to_string(),
     });
@@ -100,6 +104,32 @@ fn make_agent(reply: &str) -> Arc<Agent> {
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn spawn_child_has_independent_budget() {
+    let config = AgentConfig {
+        max_iterations: 5,
+        ..AgentConfig::default()
+    };
+    let parent = make_agent_with_config("hi", Arc::new(config));
+
+    parent.consume_budget(); // parent uses 1 → 4 remaining
+    let child = parent.spawn_child();
+
+    assert_eq!(child.budget_remaining(), 5, "child starts with full budget");
+    assert_eq!(
+        parent.budget_remaining(),
+        4,
+        "parent budget unaffected by child creation"
+    );
+
+    child.consume_budget(); // child uses 1 → 4 remaining
+    assert_eq!(
+        parent.budget_remaining(),
+        4,
+        "parent unaffected by child consumption"
+    );
+}
 
 #[tokio::test]
 async fn run_returns_reply() {


### PR DESCRIPTION
## Summary

`spawn_child()` was doing `budget: self.budget.clone()`, which clones the `Arc` — meaning the child and parent share the **same** `IterationBudget`. Every iteration the child consumed also counted against the parent's remaining quota, making the parent exhaust its budget prematurely when delegating.

**Fix:** create a fresh `IterationBudget::new(config.max_iterations)` for each child.

## Test plan

- [ ] `cargo clippy --workspace --all-targets` — no warnings
- [ ] Delegate a task that takes 3+ child iterations; confirm parent's remaining budget is unchanged afterward

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)