### PR TITLE
docs: restructure Quick Start into 3 clear modes — TUI / one-shot / server

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,31 +70,20 @@ export PATH="$PATH:$(pwd)/target/release"
 ## Quick Start
 
 ```bash
-garudust setup   # pick provider + save API key
-garudust         # launch interactive TUI
+garudust setup   # first-time wizard — pick provider, save API key
 ```
 
-Or run a one-shot task:
+Garudust ships two binaries. Pick the mode that fits:
 
-```bash
-garudust "summarise the git log from the last 7 days into a changelog"
-```
+| | `garudust` | `garudust-server` |
+|---|---|---|
+| **Use when** | Personal use on your terminal | Deploy bots or expose an HTTP API |
+| **Interface** | TUI / one-shot CLI | Background process / Docker |
+| **Chat apps** | — | Telegram, Discord, Slack, Matrix, LINE |
+| **HTTP API** | — | REST, SSE, WebSocket |
+| **Cron jobs** | — | Built-in scheduler |
 
-**Server mode with Docker:**
-
-```bash
-echo "OPENROUTER_API_KEY=sk-or-..." > .env
-docker compose up
-curl -X POST http://localhost:3000/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message": "what is 2+2?"}'
-```
-
----
-
-## CLI Usage
-
-### Interactive TUI
+### 1 — Interactive TUI
 
 ```bash
 garudust
@@ -109,7 +98,36 @@ garudust
 | `/help` | Show all slash commands |
 | `Ctrl+C` | Quit |
 
-### Config commands
+### 2 — One-shot
+
+```bash
+garudust "summarise the git log from the last 7 days into a changelog"
+```
+
+Output goes to stdout. Exit code is 0 on success. Pipe-friendly.
+
+### 3 — Server / Docker
+
+```bash
+# Minimal
+garudust-server --port 3000
+
+# With Docker
+echo "OPENROUTER_API_KEY=sk-or-..." > .env
+docker compose up
+
+# Production: sandbox + Telegram bot + daily cron
+GARUDUST_TERMINAL_SANDBOX=docker \
+GARUDUST_API_KEY=my-secret-token \
+TELEGRAM_TOKEN=123:ABC \
+GARUDUST_CRON_JOBS="0 9 * * *=Post a morning briefing to Telegram" \
+GARUDUST_MEMORY_CRON="0 3 * * *" \
+garudust-server --port 3000 --approval-mode smart
+```
+
+---
+
+## CLI Reference
 
 ```bash
 garudust setup                              # first-time wizard
@@ -150,41 +168,6 @@ mcp_servers:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
 ```
-
-## Running Garudust
-
-Garudust ships two binaries with different purposes:
-
-| | `garudust` | `garudust-server` |
-|---|---|---|
-| **Use when** | Personal use on your own terminal | Deploying bots or exposing an API |
-| **Interface** | Interactive TUI / one-shot CLI | Background process / Docker |
-| **Chat apps** | — | Telegram, Discord, Slack, Matrix, LINE |
-| **HTTP API** | — | REST, SSE, WebSocket |
-| **Cron jobs** | — | Built-in scheduler |
-
-Run `garudust setup` once to configure credentials, then start the binary you need.
-
-### Start the server
-
-Minimal:
-
-```bash
-garudust-server --port 3000
-```
-
-Production setup with sandbox, Telegram, and scheduled tasks:
-
-```bash
-GARUDUST_TERMINAL_SANDBOX=docker \
-GARUDUST_API_KEY=my-secret-token \
-TELEGRAM_TOKEN=123:ABC \
-GARUDUST_CRON_JOBS="0 9 * * *=Post a morning briefing to Telegram" \
-GARUDUST_MEMORY_CRON="0 3 * * *" \
-garudust-server --port 3000 --approval-mode smart
-```
-
----
 
 ## Security
 

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -66,31 +66,20 @@ export PATH="$PATH:$(pwd)/target/release"
 ## เริ่มต้นใช้งาน
 
 ```bash
-garudust setup   # เลือก provider + บันทึก API key
-garudust         # เปิด TUI แบบโต้ตอบ
+garudust setup   # wizard ตั้งค่าครั้งแรก — เลือก provider, บันทึก API key
 ```
 
-หรือรันงานแบบครั้งเดียว:
+Garudust มีสอง binary เลือกแบบที่เหมาะกับการใช้งาน:
 
-```bash
-garudust "สรุป git log จาก 7 วันที่ผ่านมาเป็น changelog"
-```
+| | `garudust` | `garudust-server` |
+|---|---|---|
+| **ใช้เมื่อ** | ใช้งานส่วนตัวบน terminal | Deploy bot หรือเปิด HTTP API |
+| **อินเทอร์เฟซ** | TUI โต้ตอบ / CLI แบบ one-shot | Background process / Docker |
+| **Chat app** | — | Telegram, Discord, Slack, Matrix, LINE |
+| **HTTP API** | — | REST, SSE, WebSocket |
+| **Cron job** | — | มี scheduler ในตัว |
 
-**Server mode ด้วย Docker:**
-
-```bash
-echo "OPENROUTER_API_KEY=sk-or-..." > .env
-docker compose up
-curl -X POST http://localhost:3000/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message": "2+2 เท่ากับเท่าไร?"}'
-```
-
----
-
-## การใช้งาน CLI
-
-### TUI แบบโต้ตอบ
+### 1 — TUI แบบโต้ตอบ
 
 ```bash
 garudust
@@ -105,7 +94,36 @@ garudust
 | `/help` | แสดงคำสั่ง slash ทั้งหมด |
 | `Ctrl+C` | ออกจากโปรแกรม |
 
-### คำสั่ง config
+### 2 — One-shot
+
+```bash
+garudust "สรุป git log จาก 7 วันที่ผ่านมาเป็น changelog"
+```
+
+output ออก stdout, exit code 0 เมื่อสำเร็จ ใช้กับ pipe ได้เลย
+
+### 3 — Server / Docker
+
+```bash
+# แบบพื้นฐาน
+garudust-server --port 3000
+
+# ด้วย Docker
+echo "OPENROUTER_API_KEY=sk-or-..." > .env
+docker compose up
+
+# Production: sandbox + Telegram bot + cron รายวัน
+GARUDUST_TERMINAL_SANDBOX=docker \
+GARUDUST_API_KEY=my-secret-token \
+TELEGRAM_TOKEN=123:ABC \
+GARUDUST_CRON_JOBS="0 9 * * *=โพสต์สรุปเช้าไปยัง Telegram" \
+GARUDUST_MEMORY_CRON="0 3 * * *" \
+garudust-server --port 3000 --approval-mode smart
+```
+
+---
+
+## คำสั่ง CLI
 
 ```bash
 garudust setup                              # wizard ตั้งค่า
@@ -146,41 +164,6 @@ mcp_servers:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
 ```
-
-## การรัน Garudust
-
-Garudust มีสอง binary ที่มีจุดประสงค์ต่างกัน:
-
-| | `garudust` | `garudust-server` |
-|---|---|---|
-| **ใช้เมื่อ** | ใช้งานส่วนตัวบน terminal | Deploy bot หรือเปิด API |
-| **อินเทอร์เฟซ** | TUI โต้ตอบ / CLI แบบ one-shot | Background process / Docker |
-| **Chat app** | — | Telegram, Discord, Slack, Matrix, LINE |
-| **HTTP API** | — | REST, SSE, WebSocket |
-| **Cron job** | — | มี scheduler ในตัว |
-
-รัน `garudust setup` ครั้งเดียวเพื่อตั้งค่า credential แล้วเริ่ม binary ที่ต้องการ
-
-### เปิด server
-
-แบบพื้นฐาน:
-
-```bash
-garudust-server --port 3000
-```
-
-Production พร้อม sandbox, Telegram และ cron job:
-
-```bash
-GARUDUST_TERMINAL_SANDBOX=docker \
-GARUDUST_API_KEY=my-secret-token \
-TELEGRAM_TOKEN=123:ABC \
-GARUDUST_CRON_JOBS="0 9 * * *=โพสต์สรุปเช้าไปยัง Telegram" \
-GARUDUST_MEMORY_CRON="0 3 * * *" \
-garudust-server --port 3000 --approval-mode smart
-```
-
----
 
 ## ความปลอดภัย
 

--- a/docs/i18n/zh/README.md
+++ b/docs/i18n/zh/README.md
@@ -66,31 +66,20 @@ export PATH="$PATH:$(pwd)/target/release"
 ## 快速开始
 
 ```bash
-garudust setup   # 选择提供商并保存 API key
-garudust         # 启动交互式 TUI
+garudust setup   # 首次配置向导 — 选择提供商并保存 API key
 ```
 
-或执行单次任务：
+Garudust 提供两个可执行文件，按需选择：
 
-```bash
-garudust "将过去 7 天的 git log 整理成 changelog"
-```
+| | `garudust` | `garudust-server` |
+|---|---|---|
+| **适用场景** | 个人在终端使用 | 部署机器人或对外提供 HTTP API |
+| **交互方式** | 交互式 TUI / 单次 CLI | 后台进程 / Docker |
+| **聊天应用** | — | Telegram、Discord、Slack、Matrix、LINE |
+| **HTTP API** | — | REST、SSE、WebSocket |
+| **定时任务** | — | 内置调度器 |
 
-**Docker 服务器模式：**
-
-```bash
-echo "OPENROUTER_API_KEY=sk-or-..." > .env
-docker compose up
-curl -X POST http://localhost:3000/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message": "2+2 等于多少？"}'
-```
-
----
-
-## CLI 用法
-
-### 交互式 TUI
+### 1 — 交互式 TUI
 
 ```bash
 garudust
@@ -105,7 +94,36 @@ garudust
 | `/help` | 显示所有斜杠命令 |
 | `Ctrl+C` | 退出 |
 
-### 配置命令
+### 2 — 单次执行
+
+```bash
+garudust "将过去 7 天的 git log 整理成 changelog"
+```
+
+输出到 stdout，成功时退出码为 0，可直接与管道配合使用。
+
+### 3 — 服务器 / Docker
+
+```bash
+# 最简启动
+garudust-server --port 3000
+
+# 使用 Docker
+echo "OPENROUTER_API_KEY=sk-or-..." > .env
+docker compose up
+
+# 生产环境：沙箱 + Telegram 机器人 + 每日定时任务
+GARUDUST_TERMINAL_SANDBOX=docker \
+GARUDUST_API_KEY=my-secret-token \
+TELEGRAM_TOKEN=123:ABC \
+GARUDUST_CRON_JOBS="0 9 * * *=向 Telegram 发送晨报" \
+GARUDUST_MEMORY_CRON="0 3 * * *" \
+garudust-server --port 3000 --approval-mode smart
+```
+
+---
+
+## CLI 参考
 
 ```bash
 garudust setup                              # 首次配置向导
@@ -146,41 +164,6 @@ mcp_servers:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
 ```
-
-## 运行 Garudust
-
-Garudust 提供两个用途不同的可执行文件：
-
-| | `garudust` | `garudust-server` |
-|---|---|---|
-| **适用场景** | 个人在终端使用 | 部署机器人或对外提供 API |
-| **交互方式** | 交互式 TUI / 单次 CLI | 后台进程 / Docker |
-| **聊天应用** | — | Telegram、Discord、Slack、Matrix、LINE |
-| **HTTP API** | — | REST、SSE、WebSocket |
-| **定时任务** | — | 内置调度器 |
-
-先运行一次 `garudust setup` 完成凭据配置，再启动所需的可执行文件。
-
-### 启动服务器
-
-最简启动：
-
-```bash
-garudust-server --port 3000
-```
-
-生产环境（沙箱 + Telegram + 定时任务）：
-
-```bash
-GARUDUST_TERMINAL_SANDBOX=docker \
-GARUDUST_API_KEY=my-secret-token \
-TELEGRAM_TOKEN=123:ABC \
-GARUDUST_CRON_JOBS="0 9 * * *=向 Telegram 发送晨报" \
-GARUDUST_MEMORY_CRON="0 3 * * *" \
-garudust-server --port 3000 --approval-mode smart
-```
-
----
 
 ## 安全性
 


### PR DESCRIPTION
## Summary

- **Comparison table** moved to the top of Quick Start so readers immediately know which binary to use
- **3 numbered sub-sections** replace the previous scattered examples: TUI, One-shot, Server/Docker — each with a concise code block
- **Removed duplicate sections**: "Running Garudust" / "การรัน Garudust" / "运行 Garudust" (comparison table + server start commands) — all content is now in Quick Start
- **Renamed** "CLI Usage" → "CLI Reference" (EN/TH/ZH) to signal it's a reference, not a tutorial
- Applied consistently across **EN, TH, ZH** READMEs

Net: −171 lines / +120 lines (51 lines removed overall)

## Test plan

- [ ] Read through Quick Start — one table, three numbered sections, no duplication
- [ ] Confirm TH and ZH match EN structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)