### PR TITLE
fix(tools): reuse SessionDb connection in session_search

### DIFF
--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -163,7 +163,7 @@ async fn build_agent(config: Arc<AgentConfig>, db: Arc<SessionDb>) -> Arc<Agent>
     registry.register(Terminal);
     registry.register(MemoryTool);
     registry.register(UserProfileTool);
-    registry.register(SessionSearch);
+    registry.register(SessionSearch::new(db.clone()));
     registry.register(SkillsList);
     registry.register(SkillView);
     registry.register(WriteSkill);

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -128,6 +128,8 @@ async fn build_agent(config: Arc<AgentConfig>) -> (Arc<Agent>, McpHandles) {
         );
     }
 
+    let db = SessionDb::open(&config.home_dir).ok().map(Arc::new);
+
     let mut registry = ToolRegistry::new();
     registry.register(WebFetch);
     registry.register(WebSearch);
@@ -138,7 +140,9 @@ async fn build_agent(config: Arc<AgentConfig>) -> (Arc<Agent>, McpHandles) {
     registry.register(Terminal);
     registry.register(MemoryTool);
     registry.register(UserProfileTool);
-    registry.register(SessionSearch);
+    if let Some(ref db) = db {
+        registry.register(SessionSearch::new(db.clone()));
+    }
     registry.register(SkillsList);
     registry.register(SkillView);
     registry.register(WriteSkill);
@@ -147,7 +151,6 @@ async fn build_agent(config: Arc<AgentConfig>) -> (Arc<Agent>, McpHandles) {
 
     let mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;
 
-    let db = SessionDb::open(&config.home_dir).ok().map(Arc::new);
     let agent = Agent::new(transport, Arc::new(registry), memory, config);
     let agent = match db {
         Some(db) => agent.with_session_db(db),

--- a/crates/garudust-tools/src/toolsets/search.rs
+++ b/crates/garudust-tools/src/toolsets/search.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use garudust_core::{
     error::ToolError,
@@ -7,7 +9,15 @@ use garudust_core::{
 use garudust_memory::SessionDb;
 use serde_json::json;
 
-pub struct SessionSearch;
+pub struct SessionSearch {
+    db: Arc<SessionDb>,
+}
+
+impl SessionSearch {
+    pub fn new(db: Arc<SessionDb>) -> Self {
+        Self { db }
+    }
+}
 
 #[async_trait]
 impl Tool for SessionSearch {
@@ -42,7 +52,7 @@ impl Tool for SessionSearch {
     async fn execute(
         &self,
         params: serde_json::Value,
-        ctx: &ToolContext,
+        _ctx: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let query = params["query"]
             .as_str()
@@ -50,10 +60,8 @@ impl Tool for SessionSearch {
 
         let limit = params["limit"].as_u64().unwrap_or(10).min(50) as usize;
 
-        let db = SessionDb::open(&ctx.config.home_dir)
-            .map_err(|e| ToolError::Execution(e.to_string()))?;
-
-        let results = db
+        let results = self
+            .db
             .search(query, limit)
             .map_err(|e| ToolError::Execution(e.to_string()))?;
 


### PR DESCRIPTION
## Summary

`SessionSearch` previously called `SessionDb::open()` on every tool invocation, creating a new SQLite connection each time. `SessionDb` already wraps its connection in `Arc<Mutex<Connection>>` so it's safe to share across calls.

- `SessionSearch` is now a struct holding `Arc<SessionDb>` — same pattern as `BrowserTool`
- Add `SessionSearch::new(db: Arc<SessionDb>)` constructor
- **CLI** (`bin/garudust`): open db before building the registry; register `SessionSearch::new(db.clone())` only when the db opens successfully (preserves existing graceful-degradation if SQLite is unavailable)
- **Server** (`bin/garudust-server`): pass the already-open `Arc<SessionDb>` from `build_agent`'s parameter — zero new allocations

## Test plan

- [ ] `cargo clippy` is clean
- [ ] `cargo fmt -- --check` passes
- [ ] `cargo test --workspace` passes (all green)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)