### PR TITLE
chore: commit Cargo.lock update for tempfile dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",


### PR DESCRIPTION
`tempfile` was added to `garudust-tools` `[dev-dependencies]` in #73 but `Cargo.lock` was not staged in that PR. This commit adds the missing lock file entry (1 line — just wires `tempfile` into the `garudust-tools` package entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)