### PR TITLE
docs: remind contributors to stage Cargo.lock when Cargo.toml changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,14 @@ cargo test --workspace
 
 All four must be green. CI runs the same commands with `RUSTFLAGS=-D warnings`.
 
+If you changed `Cargo.toml` (added/removed/bumped a dependency), stage `Cargo.lock` too:
+
+```bash
+git add Cargo.lock
+```
+
+`Cargo.lock` is committed in this repo because it pins exact dependency versions for reproducible builds. Leaving it out of the PR causes a stale-lock diff on `main`.
+
 ### Opening the PR
 
 - Title: one Conventional Commit line (`feat(tools): add http_request tool`)


### PR DESCRIPTION
`Cargo.lock` was left out of PR #73 when `tempfile` was added as a dev-dependency, causing a stale-lock diff on `main` (fixed in #75).

Added a note to the pre-PR checklist in `CONTRIBUTING.md` so this is easy to catch before opening a PR — explains what to do and why the lock file is committed in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)