### PR TITLE
docs: redesign architecture diagram and crate layout (all languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,44 +338,54 @@ Set the relevant key in `~/.garudust/.env`, then switch models with `garudust mo
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│                        garudust-server                           │
-│                                                                  │
-│  HTTP /chat ────┐                                                │
-│  HTTP /stream   │                                                │
-│  WebSocket ─────┼──► GatewayHandler ──► ArcSwap<Agent>          │
-│  Telegram       │                            │                   │
-│  Discord        │                            ▼                   │
-│  Slack ─────────┘                       run_loop()               │
-│  Matrix                                  │         │             │
-│  LINE                                                             │
-│  Cron ──────────────────────────►   Transport   ToolRegistry     │
-│                                    (Anthropic    (web, browser,  │
-│                                     OpenRouter   file, terminal, │
-│                                     Bedrock      memory, MCP,    │
-│                                     Codex        delegate, ...)  │
-│                                     Ollama                       │
-│                                     vLLM)                        │
-└──────────────────────────────────────────────────────────────────┘
+  garudust (CLI)              garudust-server
+  ┌────────────────────┐    ┌─────────────────────────────────────────────┐
+  │  TUI / one-shot    │    │  HTTP /chat · /stream · /ws                 │
+  │  setup · config    ├──┐ │  Telegram · Discord · Slack · Matrix · LINE │
+  │  doctor · model    │  │ │  Webhook · Cron                             │
+  └────────────────────┘  │ └──────────────────────────┬──────────────────┘
+                          │                            │
+                          └─────────────┬──────────────┘
+                                        ▼
+                               ┌─────────────────┐
+                               │      Agent       │
+                               │   run_loop()     │
+                               └────────┬─────────┘
+                            ┌───────────┴───────────┐
+                            ▼                       ▼
+              ┌──────────────────────┐  ┌─────────────────────────────────┐
+              │      Transport       │  │        ToolRegistry              │
+              │  Anthropic           │  │  web_fetch · web_search          │
+              │  OpenRouter          │  │  http_request · browser          │
+              │  AWS Bedrock         │  │  read_file · write_file          │
+              │  Codex               │  │  list_directory · terminal       │
+              │  Ollama · vLLM       │  │  memory · user_profile           │
+              └──────────────────────┘  │  session_search · delegate_task  │
+                                        │  skills · + MCP (external)       │
+                                        └─────────────┬───────────────────┘
+                                                      │
+                                          ┌───────────┴───────────┐
+                                          ▼                       ▼
+                                ┌──────────────────┐  ┌──────────────────────┐
+                                │ FileMemoryStore   │  │      SessionDb       │
+                                │ memory/ · skills/ │  │   SQLite + FTS5      │
+                                └──────────────────┘  └──────────────────────┘
 ```
 
 ### Crate layout
 
-```
-crates/
-  garudust-core        Shared traits & types — zero I/O
-  garudust-transport   LLM adapters: Anthropic, OpenAI-compat, Codex, Bedrock, Ollama, vLLM
-  garudust-tools       Tool registry + built-in toolsets (web, browser, file, …)
-  garudust-memory      FileMemoryStore (markdown) + SessionDb (SQLite + FTS5)
-  garudust-agent       Agent run loop, context compressor, prompt builder
-  garudust-platforms   Telegram, Discord, Slack, Matrix, LINE, Webhook
-  garudust-cron        Cron scheduler
-  garudust-gateway     axum HTTP gateway — /chat, /chat/stream, /chat/ws, /metrics
-
-bin/
-  garudust             CLI: interactive TUI, one-shot, setup, doctor, config, model
-  garudust-server      Headless: all platforms + HTTP + cron in one process
-```
+| Crate / Binary | Role |
+|---|---|
+| `garudust-core` | Shared traits & types — zero I/O |
+| `garudust-transport` | LLM adapters: Anthropic, OpenAI-compat, Bedrock, Codex, Ollama, vLLM |
+| `garudust-tools` | Tool registry + built-in toolsets (web, files, terminal, browser, …) |
+| `garudust-memory` | `FileMemoryStore` (markdown) + `SessionDb` (SQLite + FTS5) |
+| `garudust-agent` | Agent run loop, context compressor, prompt builder |
+| `garudust-platforms` | Telegram, Discord, Slack, Matrix, LINE, Webhook |
+| `garudust-cron` | Cron scheduler |
+| `garudust-gateway` | axum HTTP gateway — `/chat`, `/chat/stream`, `/chat/ws`, `/metrics` |
+| `bin/garudust` | CLI: interactive TUI, one-shot, `setup`, `config`, `doctor`, `model` |
+| `bin/garudust-server` | Headless: all platforms + HTTP gateway + cron in one process |
 
 ---
 

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -339,44 +339,54 @@ curl http://localhost:3000/metrics   # รองรับ Prometheus
 ## สถาปัตยกรรม
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│                        garudust-server                           │
-│                                                                  │
-│  HTTP /chat ────┐                                                │
-│  HTTP /stream   │                                                │
-│  WebSocket ─────┼──► GatewayHandler ──► ArcSwap<Agent>          │
-│  Telegram       │                            │                   │
-│  Discord        │                            ▼                   │
-│  Slack ─────────┘                       run_loop()               │
-│  Matrix                                  │         │             │
-│  LINE                                                             │
-│  Cron ──────────────────────────►   Transport   ToolRegistry     │
-│                                    (Anthropic    (web, browser,  │
-│                                     OpenRouter   file, terminal, │
-│                                     Bedrock      memory, MCP,    │
-│                                     Codex        delegate, ...)  │
-│                                     Ollama                       │
-│                                     vLLM)                        │
-└──────────────────────────────────────────────────────────────────┘
+  garudust (CLI)              garudust-server
+  ┌────────────────────┐    ┌─────────────────────────────────────────────┐
+  │  TUI / one-shot    │    │  HTTP /chat · /stream · /ws                 │
+  │  setup · config    ├──┐ │  Telegram · Discord · Slack · Matrix · LINE │
+  │  doctor · model    │  │ │  Webhook · Cron                             │
+  └────────────────────┘  │ └──────────────────────────┬──────────────────┘
+                          │                            │
+                          └─────────────┬──────────────┘
+                                        ▼
+                               ┌─────────────────┐
+                               │      Agent       │
+                               │   run_loop()     │
+                               └────────┬─────────┘
+                            ┌───────────┴───────────┐
+                            ▼                       ▼
+              ┌──────────────────────┐  ┌─────────────────────────────────┐
+              │      Transport       │  │        ToolRegistry              │
+              │  Anthropic           │  │  web_fetch · web_search          │
+              │  OpenRouter          │  │  http_request · browser          │
+              │  AWS Bedrock         │  │  read_file · write_file          │
+              │  Codex               │  │  list_directory · terminal       │
+              │  Ollama · vLLM       │  │  memory · user_profile           │
+              └──────────────────────┘  │  session_search · delegate_task  │
+                                        │  skills · + MCP (external)       │
+                                        └─────────────┬───────────────────┘
+                                                      │
+                                          ┌───────────┴───────────┐
+                                          ▼                       ▼
+                                ┌──────────────────┐  ┌──────────────────────┐
+                                │ FileMemoryStore   │  │      SessionDb       │
+                                │ memory/ · skills/ │  │   SQLite + FTS5      │
+                                └──────────────────┘  └──────────────────────┘
 ```
 
 ### โครงสร้าง Crate
 
-```
-crates/
-  garudust-core        trait และ type ที่ใช้ร่วมกัน — ไม่มี I/O
-  garudust-transport   LLM adapter: Anthropic, OpenAI-compat, Codex, Bedrock, Ollama, vLLM
-  garudust-tools       Tool registry + toolset ในตัว (web, browser, file, …)
-  garudust-memory      FileMemoryStore (markdown) + SessionDb (SQLite + FTS5)
-  garudust-agent       Agent run loop, context compressor, prompt builder
-  garudust-platforms   Telegram, Discord, Slack, Matrix, LINE, Webhook
-  garudust-cron        Cron scheduler
-  garudust-gateway     axum HTTP gateway — /chat, /chat/stream, /chat/ws, /metrics
-
-bin/
-  garudust             CLI: TUI โต้ตอบ, one-shot, setup, doctor, config, model
-  garudust-server      Headless: ทุกแพลตฟอร์ม + HTTP + cron ในกระบวนการเดียว
-```
+| Crate / Binary | บทบาท |
+|---|---|
+| `garudust-core` | Trait และ type ที่ใช้ร่วมกัน — ไม่มี I/O |
+| `garudust-transport` | LLM adapter: Anthropic, OpenAI-compat, Bedrock, Codex, Ollama, vLLM |
+| `garudust-tools` | Tool registry + toolset ในตัว (web, files, terminal, browser, …) |
+| `garudust-memory` | `FileMemoryStore` (markdown) + `SessionDb` (SQLite + FTS5) |
+| `garudust-agent` | Agent run loop, context compressor, prompt builder |
+| `garudust-platforms` | Telegram, Discord, Slack, Matrix, LINE, Webhook |
+| `garudust-cron` | Cron scheduler |
+| `garudust-gateway` | axum HTTP gateway — `/chat`, `/chat/stream`, `/chat/ws`, `/metrics` |
+| `bin/garudust` | CLI: TUI โต้ตอบ, one-shot, `setup`, `config`, `doctor`, `model` |
+| `bin/garudust-server` | Headless: ทุกแพลตฟอร์ม + HTTP gateway + cron ในกระบวนการเดียว |
 
 ---
 

--- a/docs/i18n/zh/README.md
+++ b/docs/i18n/zh/README.md
@@ -337,44 +337,54 @@ curl http://localhost:3000/metrics   # Prometheus 兼容
 ## 架构
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│                        garudust-server                           │
-│                                                                  │
-│  HTTP /chat ────┐                                                │
-│  HTTP /stream   │                                                │
-│  WebSocket ─────┼──► GatewayHandler ──► ArcSwap<Agent>          │
-│  Telegram       │                            │                   │
-│  Discord        │                            ▼                   │
-│  Slack ─────────┘                       run_loop()               │
-│  Matrix                                  │         │             │
-│  LINE                                                             │
-│  Cron ──────────────────────────►   Transport   ToolRegistry     │
-│                                    (Anthropic    (web, browser,  │
-│                                     OpenRouter   file, terminal, │
-│                                     Bedrock      memory, MCP,    │
-│                                     Codex        delegate, ...)  │
-│                                     Ollama                       │
-│                                     vLLM)                        │
-└──────────────────────────────────────────────────────────────────┘
+  garudust (CLI)              garudust-server
+  ┌────────────────────┐    ┌─────────────────────────────────────────────┐
+  │  TUI / one-shot    │    │  HTTP /chat · /stream · /ws                 │
+  │  setup · config    ├──┐ │  Telegram · Discord · Slack · Matrix · LINE │
+  │  doctor · model    │  │ │  Webhook · Cron                             │
+  └────────────────────┘  │ └──────────────────────────┬──────────────────┘
+                          │                            │
+                          └─────────────┬──────────────┘
+                                        ▼
+                               ┌─────────────────┐
+                               │      Agent       │
+                               │   run_loop()     │
+                               └────────┬─────────┘
+                            ┌───────────┴───────────┐
+                            ▼                       ▼
+              ┌──────────────────────┐  ┌─────────────────────────────────┐
+              │      Transport       │  │        ToolRegistry              │
+              │  Anthropic           │  │  web_fetch · web_search          │
+              │  OpenRouter          │  │  http_request · browser          │
+              │  AWS Bedrock         │  │  read_file · write_file          │
+              │  Codex               │  │  list_directory · terminal       │
+              │  Ollama · vLLM       │  │  memory · user_profile           │
+              └──────────────────────┘  │  session_search · delegate_task  │
+                                        │  skills · + MCP (external)       │
+                                        └─────────────┬───────────────────┘
+                                                      │
+                                          ┌───────────┴───────────┐
+                                          ▼                       ▼
+                                ┌──────────────────┐  ┌──────────────────────┐
+                                │ FileMemoryStore   │  │      SessionDb       │
+                                │ memory/ · skills/ │  │   SQLite + FTS5      │
+                                └──────────────────┘  └──────────────────────┘
 ```
 
 ### Crate 布局
 
-```
-crates/
-  garudust-core        共享 trait 和类型 — 零 I/O
-  garudust-transport   LLM 适配器：Anthropic、OpenAI-compat、Codex、Bedrock、Ollama、vLLM
-  garudust-tools       工具注册表 + 内置工具集（web、browser、file 等）
-  garudust-memory      FileMemoryStore（markdown）+ SessionDb（SQLite + FTS5）
-  garudust-agent       Agent 运行循环、上下文压缩器、提示构建器
-  garudust-platforms   Telegram、Discord、Slack、Matrix、LINE、Webhook
-  garudust-cron        定时调度器
-  garudust-gateway     axum HTTP 网关 — /chat、/chat/stream、/chat/ws、/metrics
-
-bin/
-  garudust             CLI：交互式 TUI、单次任务、setup、doctor、config、model
-  garudust-server      无头模式：所有平台 + HTTP + 定时任务，单进程运行
-```
+| Crate / 二进制 | 职责 |
+|---|---|
+| `garudust-core` | 共享 trait 和类型 — 零 I/O |
+| `garudust-transport` | LLM 适配器：Anthropic、OpenAI-compat、Bedrock、Codex、Ollama、vLLM |
+| `garudust-tools` | 工具注册表 + 内置工具集（web、files、terminal、browser 等） |
+| `garudust-memory` | `FileMemoryStore`（markdown）+ `SessionDb`（SQLite + FTS5） |
+| `garudust-agent` | Agent 运行循环、上下文压缩器、提示构建器 |
+| `garudust-platforms` | Telegram、Discord、Slack、Matrix、LINE、Webhook |
+| `garudust-cron` | 定时调度器 |
+| `garudust-gateway` | axum HTTP 网关 — `/chat`、`/chat/stream`、`/chat/ws`、`/metrics` |
+| `bin/garudust` | CLI：交互式 TUI、单次任务、`setup`、`config`、`doctor`、`model` |
+| `bin/garudust-server` | 无头模式：所有平台 + HTTP 网关 + 定时任务，单进程运行 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace the old single-box ASCII diagram with a layered flow diagram showing the full data path: entry points → Agent → Transport / ToolRegistry → storage
- Update ToolRegistry listing to include tools added since the last diagram update: `http_request`, `list_directory`, `session_search`, `user_profile`
- Replace the crate layout plain-text code block with a proper markdown table — consistent with the table already in CONTRIBUTING.md and renders better on GitHub
- Applied identically to all three README languages (EN, TH, ZH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)