### PR TITLE
docs: add platform adapter logo badges to all README languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,17 @@ curl http://localhost:3000/metrics   # Prometheus-compatible
 
 Set the relevant tokens in `~/.garudust/.env` and start `garudust-server`. Every adapter runs together in the same process.
 
+<div align="center">
+
+[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge)](https://core.telegram.org/bots)
+[![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.com/developers/applications)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge)](https://api.slack.com/apps)
+[![Matrix](https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge)](https://matrix.org)
+[![LINE](https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge)](https://developers.line.biz/console/)
+[![Webhook](https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge)](#headless-server)
+
+</div>
+
 | Platform | Required tokens |
 |----------|-----------------|
 | Telegram | `TELEGRAM_TOKEN` |

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -276,6 +276,17 @@ curl http://localhost:3000/metrics   # รองรับ Prometheus
 
 ตั้งค่า token ที่เกี่ยวข้องใน `~/.garudust/.env` แล้วสตาร์ท `garudust-server` — ทุก adapter รันในกระบวนการเดียวกันได้
 
+<div align="center">
+
+[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge)](https://core.telegram.org/bots)
+[![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.com/developers/applications)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge)](https://api.slack.com/apps)
+[![Matrix](https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge)](https://matrix.org)
+[![LINE](https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge)](https://developers.line.biz/console/)
+[![Webhook](https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge)](#headless-server)
+
+</div>
+
 | แพลตฟอร์ม | Token ที่ต้องการ |
 |-----------|-----------------|
 | Telegram | `TELEGRAM_TOKEN` |

--- a/docs/i18n/zh/README.md
+++ b/docs/i18n/zh/README.md
@@ -274,6 +274,17 @@ curl http://localhost:3000/metrics   # Prometheus 兼容
 
 在 `~/.garudust/.env` 中设置相关令牌并启动 `garudust-server`，所有适配器可在同一进程中同时运行。
 
+<div align="center">
+
+[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge)](https://core.telegram.org/bots)
+[![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.com/developers/applications)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge)](https://api.slack.com/apps)
+[![Matrix](https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge)](https://matrix.org)
+[![LINE](https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge)](https://developers.line.biz/console/)
+[![Webhook](https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge)](#headless-server)
+
+</div>
+
 | 平台 | 所需令牌 |
 |------|---------|
 | Telegram | `TELEGRAM_TOKEN` |


### PR DESCRIPTION
## Summary

- Adds a `<div align="center">` block of shields.io `for-the-badge` badges between the intro paragraph and the token table in the Platform Adapters section
- Applied to all three README languages: English, Thai, and Chinese
- Each badge links to the relevant developer docs (Telegram Bot API, Discord Developers, Slack API, Matrix.org, LINE Developers, Headless Server section)
- Brand colors used: Telegram `#2CA5E0`, Discord `#5865F2`, Slack `#4A154B`, Matrix `#000000`, LINE `#00C300`, Webhook `#6E7681` (neutral gray)

## Test plan

- [ ] Open each README on GitHub and verify badges render correctly with logos and colors
- [ ] Confirm each badge links to the correct external URL / anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)