### PR TITLE
docs: move platform badges to top header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
   <a href="README.md"><img src="https://img.shields.io/badge/🇺🇸-English-blue?style=flat-square" alt="English"/></a>
   <a href="docs/i18n/th/README.md"><img src="https://img.shields.io/badge/🇹🇭-ภาษาไทย-red?style=flat-square" alt="ภาษาไทย"/></a>
   <a href="docs/i18n/zh/README.md"><img src="https://img.shields.io/badge/🇨🇳-简体中文-yellow?style=flat-square" alt="简体中文"/></a>
+
+  <br/>
+
+  <a href="https://core.telegram.org/bots"><img src="https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge" alt="Telegram"/></a>
+  <a href="https://discord.com/developers/applications"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge" alt="Discord"/></a>
+  <a href="https://api.slack.com/apps"><img src="https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge" alt="Slack"/></a>
+  <a href="https://matrix.org"><img src="https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge" alt="Matrix"/></a>
+  <a href="https://developers.line.biz/console/"><img src="https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge" alt="LINE"/></a>
+  <img src="https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge" alt="Webhook"/>
 </div>
 
 # Garudust Agent
@@ -273,17 +282,6 @@ curl http://localhost:3000/metrics   # Prometheus-compatible
 ## Platform Adapters
 
 Set the relevant tokens in `~/.garudust/.env` and start `garudust-server`. Every adapter runs together in the same process.
-
-<div align="center">
-
-[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge)](https://core.telegram.org/bots)
-[![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.com/developers/applications)
-[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge)](https://api.slack.com/apps)
-[![Matrix](https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge)](https://matrix.org)
-[![LINE](https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge)](https://developers.line.biz/console/)
-[![Webhook](https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge)](#headless-server)
-
-</div>
 
 | Platform | Required tokens |
 |----------|-----------------|

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -4,6 +4,15 @@
   <a href="../../../README.md"><img src="https://img.shields.io/badge/🇺🇸-English-blue?style=flat-square" alt="English"/></a>
   <a href="../th/README.md"><img src="https://img.shields.io/badge/🇹🇭-ภาษาไทย-red?style=flat-square" alt="ภาษาไทย"/></a>
   <a href="../zh/README.md"><img src="https://img.shields.io/badge/🇨🇳-简体中文-yellow?style=flat-square" alt="简体中文"/></a>
+
+  <br/>
+
+  <a href="https://core.telegram.org/bots"><img src="https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge" alt="Telegram"/></a>
+  <a href="https://discord.com/developers/applications"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge" alt="Discord"/></a>
+  <a href="https://api.slack.com/apps"><img src="https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge" alt="Slack"/></a>
+  <a href="https://matrix.org"><img src="https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge" alt="Matrix"/></a>
+  <a href="https://developers.line.biz/console/"><img src="https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge" alt="LINE"/></a>
+  <img src="https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge" alt="Webhook"/>
 </div>
 
 # Garudust Agent
@@ -275,17 +284,6 @@ curl http://localhost:3000/metrics   # รองรับ Prometheus
 ## Platform Adapter
 
 ตั้งค่า token ที่เกี่ยวข้องใน `~/.garudust/.env` แล้วสตาร์ท `garudust-server` — ทุก adapter รันในกระบวนการเดียวกันได้
-
-<div align="center">
-
-[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge)](https://core.telegram.org/bots)
-[![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.com/developers/applications)
-[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge)](https://api.slack.com/apps)
-[![Matrix](https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge)](https://matrix.org)
-[![LINE](https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge)](https://developers.line.biz/console/)
-[![Webhook](https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge)](#headless-server)
-
-</div>
 
 | แพลตฟอร์ม | Token ที่ต้องการ |
 |-----------|-----------------|

--- a/docs/i18n/zh/README.md
+++ b/docs/i18n/zh/README.md
@@ -4,6 +4,15 @@
   <a href="../../../README.md"><img src="https://img.shields.io/badge/🇺🇸-English-blue?style=flat-square" alt="English"/></a>
   <a href="../th/README.md"><img src="https://img.shields.io/badge/🇹🇭-ภาษาไทย-red?style=flat-square" alt="ภาษาไทย"/></a>
   <a href="../zh/README.md"><img src="https://img.shields.io/badge/🇨🇳-简体中文-yellow?style=flat-square" alt="简体中文"/></a>
+
+  <br/>
+
+  <a href="https://core.telegram.org/bots"><img src="https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge" alt="Telegram"/></a>
+  <a href="https://discord.com/developers/applications"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge" alt="Discord"/></a>
+  <a href="https://api.slack.com/apps"><img src="https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge" alt="Slack"/></a>
+  <a href="https://matrix.org"><img src="https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge" alt="Matrix"/></a>
+  <a href="https://developers.line.biz/console/"><img src="https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge" alt="LINE"/></a>
+  <img src="https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge" alt="Webhook"/>
 </div>
 
 # Garudust Agent
@@ -273,17 +282,6 @@ curl http://localhost:3000/metrics   # Prometheus 兼容
 ## 平台适配器
 
 在 `~/.garudust/.env` 中设置相关令牌并启动 `garudust-server`，所有适配器可在同一进程中同时运行。
-
-<div align="center">
-
-[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge)](https://core.telegram.org/bots)
-[![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.com/developers/applications)
-[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white&style=for-the-badge)](https://api.slack.com/apps)
-[![Matrix](https://img.shields.io/badge/Matrix-000000?logo=matrix&logoColor=white&style=for-the-badge)](https://matrix.org)
-[![LINE](https://img.shields.io/badge/LINE-00C300?logo=line&logoColor=white&style=for-the-badge)](https://developers.line.biz/console/)
-[![Webhook](https://img.shields.io/badge/Webhook-6E7681?style=for-the-badge)](#headless-server)
-
-</div>
 
 | 平台 | 所需令牌 |
 |------|---------|


### PR DESCRIPTION
## Summary

- Moves platform adapter badges (Telegram, Discord, Slack, Matrix, LINE, Webhook) from the Platform Adapters section up to the top `<div align="center">` header, below the language switcher buttons
- Removes the duplicate badge block from the Platform Adapters section
- Applied to all three README languages: English, Thai, Chinese

Closes the gap left by the squash-merge of #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)