### PR TITLE
feat(tools): add pdf_read tool for extracting text from PDF files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +834,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1243,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1673,6 +1710,8 @@ dependencies = [
  "garudust-memory",
  "globset",
  "jsonschema",
+ "lopdf 0.32.0",
+ "pdf-extract",
  "reqwest 0.12.28",
  "rmcp",
  "serde",
@@ -2553,6 +2592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2629,43 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lopdf"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e775e4ee264e8a87d50a9efef7b67b4aa988cf94e75630859875fc347e6c872b"
+dependencies = [
+ "chrono",
+ "encoding_rs",
+ "flate2",
+ "itoa",
+ "linked-hash-map",
+ "log",
+ "md5",
+ "nom",
+ "rayon",
+ "time",
+ "weezl",
+]
+
+[[package]]
+name = "lopdf"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+dependencies = [
+ "encoding_rs",
+ "flate2",
+ "indexmap",
+ "itoa",
+ "log",
+ "md-5",
+ "nom",
+ "rangemap",
+ "time",
+ "weezl",
+]
 
 [[package]]
 name = "lru"
@@ -2732,6 +2814,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,6 +2873,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,6 +2910,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3034,6 +3148,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdf-extract"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
+dependencies = [
+ "adobe-cmap-parser",
+ "encoding_rs",
+ "euclid",
+ "lopdf 0.34.0",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,10 +3230,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -3378,6 +3519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,6 +3552,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -5116,6 +5283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type1-encoding-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "typemap_rev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,6 +5358,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -5517,6 +5702,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
  "garudust-memory",
  "globset",
  "jsonschema",
- "lopdf 0.32.0",
+ "lopdf",
  "pdf-extract",
  "reqwest 0.12.28",
  "rmcp",
@@ -2592,12 +2592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,29 +2626,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lopdf"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e775e4ee264e8a87d50a9efef7b67b4aa988cf94e75630859875fc347e6c872b"
-dependencies = [
- "chrono",
- "encoding_rs",
- "flate2",
- "itoa",
- "linked-hash-map",
- "log",
- "md5",
- "nom",
- "rayon",
- "time",
- "weezl",
-]
-
-[[package]]
-name = "lopdf"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
 dependencies = [
+ "chrono",
  "encoding_rs",
  "flate2",
  "indexmap",
@@ -2663,6 +2639,7 @@ dependencies = [
  "md-5",
  "nom",
  "rangemap",
+ "rayon",
  "time",
  "weezl",
 ]
@@ -2822,12 +2799,6 @@ dependencies = [
  "cfg-if",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3156,7 +3127,7 @@ dependencies = [
  "adobe-cmap-parser",
  "encoding_rs",
  "euclid",
- "lopdf 0.34.0",
+ "lopdf",
  "postscript",
  "type1-encoding-parser",
  "unicode-normalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,11 @@ base64    = "0.22"
 jsonschema = { version = "0.29", default-features = false }
 
 # Filesystem utilities
-walkdir  = "2"
-globset  = "0.4"
-tempfile = "3"
+walkdir      = "2"
+globset      = "0.4"
+tempfile     = "3"
+lopdf        = "0.32"
+pdf-extract  = "0.7"
 
 # File locking
 fs4 = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ jsonschema = { version = "0.29", default-features = false }
 walkdir      = "2"
 globset      = "0.4"
 tempfile     = "3"
-lopdf        = "0.32"
+lopdf        = "0.34"
 pdf-extract  = "0.7"
 
 # File locking

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -21,6 +21,7 @@ use garudust_tools::{
         files::{ListDirectory, ReadFile, WriteFile},
         mcp::connect_mcp_server,
         memory::{MemoryTool, UserProfileTool},
+        pdf::PdfRead,
         search::SessionSearch,
         skills::{SkillView, SkillsList, WriteSkill},
         terminal::Terminal,
@@ -160,6 +161,7 @@ async fn build_agent(config: Arc<AgentConfig>, db: Arc<SessionDb>) -> Arc<Agent>
     registry.register(ReadFile);
     registry.register(WriteFile);
     registry.register(ListDirectory);
+    registry.register(PdfRead);
     registry.register(Terminal);
     registry.register(MemoryTool);
     registry.register(UserProfileTool);

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -19,6 +19,7 @@ use garudust_tools::{
         files::{ListDirectory, ReadFile, WriteFile},
         mcp::connect_mcp_server,
         memory::{MemoryTool, UserProfileTool},
+        pdf::PdfRead,
         search::SessionSearch,
         skills::{SkillView, SkillsList, WriteSkill},
         terminal::Terminal,
@@ -137,6 +138,7 @@ async fn build_agent(config: Arc<AgentConfig>) -> (Arc<Agent>, McpHandles) {
     registry.register(ReadFile);
     registry.register(WriteFile);
     registry.register(ListDirectory);
+    registry.register(PdfRead);
     registry.register(Terminal);
     registry.register(MemoryTool);
     registry.register(UserProfileTool);

--- a/crates/garudust-tools/Cargo.toml
+++ b/crates/garudust-tools/Cargo.toml
@@ -21,6 +21,8 @@ chromiumoxide   = { workspace = true }
 jsonschema      = { workspace = true }
 walkdir         = { workspace = true }
 globset         = { workspace = true }
+lopdf           = { workspace = true }
+pdf-extract     = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/garudust-tools/src/toolsets/files.rs
+++ b/crates/garudust-tools/src/toolsets/files.rs
@@ -31,7 +31,7 @@ fn try_canonicalize(path: &Path) -> Option<PathBuf> {
 
 /// Check whether `path` is within one of the allowed root directories.
 /// Always blocks paths inside `~/.garudust/` regardless of allowed roots.
-fn is_path_allowed(path: &Path, allowed_roots: &[PathBuf]) -> bool {
+pub(crate) fn is_path_allowed(path: &Path, allowed_roots: &[PathBuf]) -> bool {
     let Some(canonical) = try_canonicalize(path) else {
         return false;
     };

--- a/crates/garudust-tools/src/toolsets/mod.rs
+++ b/crates/garudust-tools/src/toolsets/mod.rs
@@ -3,6 +3,7 @@ pub mod delegate;
 pub mod files;
 pub mod mcp;
 pub mod memory;
+pub mod pdf;
 pub mod search;
 pub mod skills;
 pub mod terminal;

--- a/crates/garudust-tools/src/toolsets/pdf.rs
+++ b/crates/garudust-tools/src/toolsets/pdf.rs
@@ -11,10 +11,7 @@ use serde_json::{json, Value};
 
 use super::files::is_path_allowed;
 
-/// Maximum bytes of extracted text returned to the agent.
 const MAX_OUTPUT_BYTES: usize = 200 * 1_024;
-
-/// Maximum pages processed in a single call.
 const MAX_PAGES: usize = 50;
 
 #[derive(Deserialize)]
@@ -23,7 +20,6 @@ struct PdfReadInput {
     pages: Option<String>,
 }
 
-/// Parse "N" or "N-M" into an inclusive 1-based page range.
 fn parse_page_range(s: &str) -> Result<(usize, usize), ToolError> {
     let s = s.trim();
     if let Some((a, b)) = s.split_once('-') {
@@ -51,11 +47,12 @@ fn parse_page_range(s: &str) -> Result<(usize, usize), ToolError> {
 }
 
 fn pdf_obj_to_string(obj: &lopdf::Object) -> Option<String> {
-    match obj {
-        lopdf::Object::String(bytes, _) => String::from_utf8(bytes.clone())
+    if let lopdf::Object::String(bytes, _) = obj {
+        String::from_utf8(bytes.clone())
             .ok()
-            .filter(|s| !s.trim().is_empty()),
-        _ => None,
+            .filter(|s| !s.trim().is_empty())
+    } else {
+        None
     }
 }
 
@@ -137,14 +134,15 @@ impl Tool for PdfRead {
             let doc =
                 lopdf::Document::load_mem(&bytes).map_err(|e| format!("PDF parse error: {e}"))?;
 
-            let page_count = doc.get_pages().len();
             let (title, author) = extract_metadata(&doc);
 
             let all_text = pdf_extract::extract_text_from_mem(&bytes)
                 .map_err(|e| format!("text extraction failed: {e}"))?;
 
-            // pdf-extract separates pages with form-feed (\x0c)
+            // pdf-extract separates pages with form-feed (\x0c); use this as
+            // the authoritative page count since both parses are from the same crate version.
             let all_pages: Vec<&str> = all_text.split('\x0c').collect();
+            let page_count = all_pages.len();
 
             let (start, end) = page_range.unwrap_or((1, MAX_PAGES.min(page_count)));
             let end = end.min(page_count).min(start + MAX_PAGES - 1);
@@ -162,13 +160,19 @@ impl Tool for PdfRead {
 
             let mut truncated = false;
             if text.len() > MAX_OUTPUT_BYTES {
-                text.truncate(MAX_OUTPUT_BYTES);
+                // Walk back from the cap to the nearest char boundary to avoid panics
+                // on multi-byte characters (CJK, accented Latin, etc.).
+                let cut = (0..=MAX_OUTPUT_BYTES)
+                    .rev()
+                    .find(|&i| text.is_char_boundary(i))
+                    .unwrap_or(0);
+                text.truncate(cut);
                 truncated = true;
             }
 
             let mut out = json!({
                 "page_count": page_count,
-                "pages_extracted": format!("{start}-{}", end.min(page_count)),
+                "pages_extracted": format!("{start}-{end}"),
                 "text": text,
             });
             if let Some(t) = title {
@@ -220,5 +224,18 @@ mod tests {
     fn rejects_garbage() {
         assert!(parse_page_range("abc").is_err());
         assert!(parse_page_range("1-abc").is_err());
+    }
+
+    #[test]
+    fn truncate_respects_char_boundary() {
+        // Simulate the truncation logic on a string with multi-byte chars.
+        let s = "日本語テスト".repeat(100); // each char is 3 bytes
+        let cap = 7; // not on a char boundary
+        let cut = (0..=cap)
+            .rev()
+            .find(|&i| s.is_char_boundary(i))
+            .unwrap_or(0);
+        assert!(s.is_char_boundary(cut));
+        assert!(cut <= cap);
     }
 }

--- a/crates/garudust-tools/src/toolsets/pdf.rs
+++ b/crates/garudust-tools/src/toolsets/pdf.rs
@@ -1,0 +1,224 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use garudust_core::{
+    error::ToolError,
+    tool::{Tool, ToolContext},
+    types::ToolResult,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::files::is_path_allowed;
+
+/// Maximum bytes of extracted text returned to the agent.
+const MAX_OUTPUT_BYTES: usize = 200 * 1_024;
+
+/// Maximum pages processed in a single call.
+const MAX_PAGES: usize = 50;
+
+#[derive(Deserialize)]
+struct PdfReadInput {
+    path: String,
+    pages: Option<String>,
+}
+
+/// Parse "N" or "N-M" into an inclusive 1-based page range.
+fn parse_page_range(s: &str) -> Result<(usize, usize), ToolError> {
+    let s = s.trim();
+    if let Some((a, b)) = s.split_once('-') {
+        let start = a
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| ToolError::InvalidArgs(format!("invalid page range: {s}")))?;
+        let end = b
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| ToolError::InvalidArgs(format!("invalid page range: {s}")))?;
+        if start == 0 || end < start {
+            return Err(ToolError::InvalidArgs(format!("invalid page range: {s}")));
+        }
+        Ok((start, end))
+    } else {
+        let page = s
+            .parse::<usize>()
+            .map_err(|_| ToolError::InvalidArgs(format!("invalid page: {s}")))?;
+        if page == 0 {
+            return Err(ToolError::InvalidArgs("page number must be >= 1".into()));
+        }
+        Ok((page, page))
+    }
+}
+
+fn pdf_obj_to_string(obj: &lopdf::Object) -> Option<String> {
+    match obj {
+        lopdf::Object::String(bytes, _) => String::from_utf8(bytes.clone())
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        _ => None,
+    }
+}
+
+fn extract_metadata(doc: &lopdf::Document) -> (Option<String>, Option<String>) {
+    let info_id = doc
+        .trailer
+        .get(b"Info")
+        .ok()
+        .and_then(|o| o.as_reference().ok());
+
+    let dict = info_id
+        .and_then(|id| doc.get_object(id).ok())
+        .and_then(|o| o.as_dict().ok());
+
+    let Some(dict) = dict else {
+        return (None, None);
+    };
+
+    let title = dict.get(b"Title").ok().and_then(pdf_obj_to_string);
+    let author = dict.get(b"Author").ok().and_then(pdf_obj_to_string);
+    (title, author)
+}
+
+pub struct PdfRead;
+
+#[async_trait]
+impl Tool for PdfRead {
+    fn name(&self) -> &'static str {
+        "pdf_read"
+    }
+
+    fn description(&self) -> &'static str {
+        "Extract plain text from a PDF file. Returns the text content, total page count, and document metadata (title, author when available)."
+    }
+
+    fn toolset(&self) -> &'static str {
+        "files"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the PDF file"
+                },
+                "pages": {
+                    "type": "string",
+                    "description": "Page range to extract, e.g. \"1-5\" or \"3\" (default: all pages, capped at 50)"
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let input: PdfReadInput =
+            serde_json::from_value(params).map_err(|e| ToolError::InvalidArgs(e.to_string()))?;
+
+        if !is_path_allowed(
+            Path::new(&input.path),
+            &ctx.config.security.allowed_read_paths,
+        ) {
+            return Err(ToolError::Execution(format!(
+                "path '{}' is outside allowed read directories",
+                input.path
+            )));
+        }
+
+        let page_range = input.pages.as_deref().map(parse_page_range).transpose()?;
+        let path = input.path.clone();
+
+        let bytes = tokio::fs::read(&path)
+            .await
+            .map_err(|e| ToolError::Execution(format!("cannot read '{path}': {e}")))?;
+
+        let result: Result<Value, String> = tokio::task::spawn_blocking(move || {
+            let doc =
+                lopdf::Document::load_mem(&bytes).map_err(|e| format!("PDF parse error: {e}"))?;
+
+            let page_count = doc.get_pages().len();
+            let (title, author) = extract_metadata(&doc);
+
+            let all_text = pdf_extract::extract_text_from_mem(&bytes)
+                .map_err(|e| format!("text extraction failed: {e}"))?;
+
+            // pdf-extract separates pages with form-feed (\x0c)
+            let all_pages: Vec<&str> = all_text.split('\x0c').collect();
+
+            let (start, end) = page_range.unwrap_or((1, MAX_PAGES.min(page_count)));
+            let end = end.min(page_count).min(start + MAX_PAGES - 1);
+
+            if start > page_count {
+                return Err(format!(
+                    "page {start} is out of range — document has {page_count} pages"
+                ));
+            }
+
+            let selected = all_pages
+                .get(start.saturating_sub(1)..end.min(all_pages.len()))
+                .unwrap_or(&[]);
+            let mut text = selected.join("\n\n");
+
+            let mut truncated = false;
+            if text.len() > MAX_OUTPUT_BYTES {
+                text.truncate(MAX_OUTPUT_BYTES);
+                truncated = true;
+            }
+
+            let mut out = json!({
+                "page_count": page_count,
+                "pages_extracted": format!("{start}-{}", end.min(page_count)),
+                "text": text,
+            });
+            if let Some(t) = title {
+                out["title"] = json!(t);
+            }
+            if let Some(a) = author {
+                out["author"] = json!(a);
+            }
+            if truncated {
+                out["truncated"] = json!(true);
+            }
+
+            Ok(out)
+        })
+        .await
+        .map_err(|e| ToolError::Execution(e.to_string()))?;
+
+        let output = result.map_err(ToolError::Execution)?;
+        Ok(ToolResult::ok("", output.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_page() {
+        assert_eq!(parse_page_range("3").unwrap(), (3, 3));
+    }
+
+    #[test]
+    fn parse_range() {
+        assert_eq!(parse_page_range("1-5").unwrap(), (1, 5));
+        assert_eq!(parse_page_range(" 2 - 10 ").unwrap(), (2, 10));
+    }
+
+    #[test]
+    fn rejects_zero_page() {
+        assert!(parse_page_range("0").is_err());
+    }
+
+    #[test]
+    fn rejects_inverted_range() {
+        assert!(parse_page_range("5-3").is_err());
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(parse_page_range("abc").is_err());
+        assert!(parse_page_range("1-abc").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `pdf_read` tool to `garudust-tools` — pure Rust, no native dependencies
- Uses `pdf-extract` (text extraction) and `lopdf` (page count + metadata) crates
- Extraction runs on a blocking thread pool via `tokio::task::spawn_blocking`

## Interface

```
pdf_read(path, pages?) -> { text, page_count, pages_extracted, title?, author?, truncated? }
```

- `path` — absolute path, checked against allowed read paths (same rules as `read_file`)
- `pages` — optional range e.g. `"1-5"` or `"3"` (default: all pages, capped at 50)
- Output truncated at 200 KB to prevent context flooding
- Page range splits on form-feed characters (`\x0c`) inserted by `pdf-extract`

## Testing

- 5 unit tests covering `parse_page_range`: single page, range, zero page, inverted range, garbage input
- All CI checks pass: `cargo check`, `clippy --pedantic`, `fmt`, `cargo test`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)