### PR TITLE
fix(setup): remove stale provider base-URL vars when switching

### DIFF
--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -187,6 +187,7 @@ async fn attach_mcp_servers(
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "warn".into()))
+        .with_writer(std::io::stderr)
         .init();
     dotenvy::dotenv().ok(); // load .env from current dir (development override)
 

--- a/bin/garudust/src/setup.rs
+++ b/bin/garudust/src/setup.rs
@@ -94,6 +94,17 @@ pub async fn run() -> anyhow::Result<()> {
     println!();
 
     // ── Credentials / endpoint ────────────────────────────────────────────────
+    // Remove base-URL env vars for providers not selected — they take priority
+    // over config.yaml in AgentConfig::load() and would override the new choice.
+    let stale_base_url_vars: &[&str] = match provider {
+        "ollama" => &["VLLM_BASE_URL"],
+        "vllm" => &["OLLAMA_BASE_URL"],
+        _ => &["OLLAMA_BASE_URL", "VLLM_BASE_URL"],
+    };
+    for var in stale_base_url_vars {
+        remove_env_var(&home_dir, var)?;
+    }
+
     let mut env_vars: Vec<(&'static str, String)> = Vec::new();
     let mut custom_base_url: Option<String> = None;
 
@@ -251,6 +262,21 @@ pub async fn run() -> anyhow::Result<()> {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Remove a key from ~/.garudust/.env if present.
+fn remove_env_var(home_dir: &Path, key: &str) -> std::io::Result<()> {
+    let env_path = home_dir.join(".env");
+    if !env_path.exists() {
+        return Ok(());
+    }
+    let content = std::fs::read_to_string(&env_path)?;
+    let prefix = format!("{key}=");
+    let filtered: Vec<&str> = content
+        .lines()
+        .filter(|l| !l.trim().starts_with(prefix.as_str()))
+        .collect();
+    std::fs::write(&env_path, filtered.join("\n") + "\n")
+}
 
 /// Read a raw value from ~/.garudust/.env without going through the OnceLock cache.
 fn read_env_file(home_dir: &Path, key: &str) -> Option<String> {


### PR DESCRIPTION
## Summary

- When switching from ollama → vllm (or vice versa), the old provider's base-URL env var (`OLLAMA_BASE_URL` / `VLLM_BASE_URL`) remained in `.env`
- `AgentConfig::load()` checks `OLLAMA_BASE_URL` before `VLLM_BASE_URL`, so the stale var silently overrode the new `provider` field in `config.yaml`
- Fix: setup now removes the non-selected provider's base-URL var from `.env` immediately after the provider choice is confirmed
- Also redirects tracing logs from stdout → stderr so they don't corrupt the TUI screen

## Test plan

- [ ] Setup with ollama → switch to vllm → run TUI — should connect to vllm URL, not localhost:11434
- [ ] Setup with vllm → switch to ollama → run TUI — should connect to ollama URL
- [ ] Tracing warn logs no longer appear inside the TUI screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)