### PR TITLE
fix(server): load ~/.garudust/.env before parsing CLI args

### DIFF
--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -274,8 +274,12 @@ fn spawn_config_watcher(
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+        .with_writer(std::io::stderr)
         .init();
-    dotenvy::dotenv().ok();
+    // Load ~/.garudust/.env first so platform tokens saved by `garudust setup`
+    // are visible to clap's env = "..." attributes below.
+    dotenvy::from_path(AgentConfig::garudust_dir().join(".env")).ok();
+    dotenvy::dotenv().ok(); // local .env override for development
 
     let cli = Cli::parse();
     let config = build_config(&cli);


### PR DESCRIPTION
## Summary

- Platform tokens saved by `garudust setup` (TELEGRAM_TOKEN, DISCORD_TOKEN, SLACK_*, MATRIX_*, LINE_*) were written to `~/.garudust/.env` but never exported to process env
- `garudust-server` reads these via clap `env = "TELEGRAM_TOKEN"` which only sees process env — so tokens from setup were silently ignored
- Fix: call `dotenvy::from_path(AgentConfig::garudust_dir().join(".env"))` before `Cli::parse()` so all setup-configured tokens are available
- `dotenvy::dotenv()` (local `.env` in current dir) still runs after, so development overrides still work
- Also redirects tracing to stderr for consistency with `garudust` CLI

## Test plan

- [ ] Run `garudust setup` (Full mode), configure Telegram token
- [ ] Run `garudust-server` with no `--telegram-token` flag — should start Telegram adapter automatically
- [ ] Environment variable override still works: `TELEGRAM_TOKEN=xxx garudust-server` takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)