### PR TITLE
fix(doctor): make API key and connectivity checks provider-aware

### DIFF
--- a/bin/garudust/src/doctor.rs
+++ b/bin/garudust/src/doctor.rs
@@ -60,25 +60,46 @@ pub async fn run(config: &AgentConfig) {
     checks.push(Check::ok("Model", &config.model));
 
     // ── API Key ──────────────────────────────────────────────────────────────
-    if let Some(k) = &config.api_key {
-        checks.push(Check::ok("API key", redact(k)));
-    } else {
-        let hint = if config.provider == "anthropic" {
-            "ANTHROPIC_API_KEY"
-        } else {
-            "OPENROUTER_API_KEY"
-        };
-        checks.push(Check::fail("API key", format!("not set — export {hint}")));
+    match config.provider.as_str() {
+        "ollama" => {
+            checks.push(Check::ok("API key", "not required (ollama)"));
+        }
+        "vllm" => {
+            if let Some(k) = &config.api_key {
+                checks.push(Check::ok("API key", redact(k)));
+            } else {
+                checks.push(Check::ok("API key", "not required (vllm)"));
+            }
+        }
+        "anthropic" => {
+            if let Some(k) = &config.api_key {
+                checks.push(Check::ok("API key", redact(k)));
+            } else {
+                checks.push(Check::fail("API key", "not set — export ANTHROPIC_API_KEY"));
+            }
+        }
+        _ => {
+            if let Some(k) = &config.api_key {
+                checks.push(Check::ok("API key", redact(k)));
+            } else {
+                checks.push(Check::fail(
+                    "API key",
+                    "not set — export OPENROUTER_API_KEY",
+                ));
+            }
+        }
     }
 
     // ── Connectivity ─────────────────────────────────────────────────────────
-    let base = config.base_url.clone().unwrap_or_else(|| {
-        if config.provider == "anthropic" {
-            "https://api.anthropic.com".into()
-        } else {
-            "https://openrouter.ai".into()
-        }
-    });
+    let base = config
+        .base_url
+        .clone()
+        .unwrap_or_else(|| match config.provider.as_str() {
+            "anthropic" => "https://api.anthropic.com".into(),
+            "ollama" => "http://localhost:11434".into(),
+            "vllm" => "http://localhost:8000".into(),
+            _ => "https://openrouter.ai".into(),
+        });
     let host = host_of(&base);
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
@@ -164,8 +185,18 @@ pub async fn run(config: &AgentConfig) {
 }
 
 fn redact(key: &str) -> String {
-    if key.len() > 10 {
-        format!("{}…{}", &key[..6], &key[key.len() - 4..])
+    let chars: Vec<char> = key.chars().collect();
+    if chars.len() > 10 {
+        let prefix: String = chars.iter().take(6).collect();
+        let suffix: String = chars
+            .iter()
+            .rev()
+            .take(4)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        format!("{prefix}…{suffix}")
     } else {
         "set".into()
     }


### PR DESCRIPTION
## Summary

- `ollama` and `vllm` do not require an API key but doctor was failing with "not set — export OPENROUTER_API_KEY" for both
- Connectivity check was hardcoded to ping `openrouter.ai` for all non-anthropic providers — vllm/ollama should ping their actual configured endpoint
- `redact()` used byte-index slicing which panics on multi-byte UTF-8 keys — fixed to use char iterators

## API key behaviour per provider

| Provider | API key |
|---|---|
| ollama | not required → always ✅ |
| vllm | optional → ✅ either way |
| anthropic | required → ✗ if missing |
| openrouter / custom | required → ✗ if missing |

## Test plan

- [ ] `garudust setup` vllm → `garudust doctor` — API key shows OK, connectivity pings vllm URL
- [ ] `garudust setup` ollama → `garudust doctor` — API key shows OK, connectivity pings localhost:11434
- [ ] `garudust setup` anthropic (no key) → `garudust doctor` — API key fails correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)