### PR TITLE
fix: detect DDG bot-detection challenge and return actionable error

### DIFF
--- a/crates/garudust-tools/src/toolsets/web.rs
+++ b/crates/garudust-tools/src/toolsets/web.rs
@@ -370,6 +370,11 @@ async fn brave_search(query: &str, count: usize, api_key: &str) -> Result<ToolRe
     Ok(ToolResult::ok("", formatted.join("\n\n")))
 }
 
+const DDG_BLOCKED_MSG: &str = "Web search is unavailable: DuckDuckGo blocked this request \
+    (bot/rate-limit detection). To enable reliable search, get a free Brave Search API key at \
+    https://brave.com/search/api/ and set BRAVE_SEARCH_API_KEY (via `garudust setup` or \
+    `garudust config set BRAVE_SEARCH_API_KEY <key>`).";
+
 async fn ddg_search(query: &str, count: usize) -> Result<ToolResult, ToolError> {
     let resp = http_client()?
         .get("https://html.duckduckgo.com/html/")
@@ -377,6 +382,11 @@ async fn ddg_search(query: &str, count: usize) -> Result<ToolResult, ToolError> 
         .send()
         .await
         .map_err(|e| ToolError::Execution(format!("DDG search failed: {e}")))?;
+
+    // DDG returns HTTP 202 when it serves a bot-detection/CAPTCHA challenge page.
+    if resp.status().as_u16() == 202 {
+        return Ok(ToolResult::ok("", DDG_BLOCKED_MSG));
+    }
 
     if !resp.status().is_success() {
         return Err(ToolError::Execution(format!(
@@ -390,11 +400,16 @@ async fn ddg_search(query: &str, count: usize) -> Result<ToolResult, ToolError> 
         .await
         .map_err(|e| ToolError::Execution(e.to_string()))?;
 
+    // Detect anomaly/CAPTCHA body even when status is 200.
+    if html.contains("anomaly.js") {
+        return Ok(ToolResult::ok("", DDG_BLOCKED_MSG));
+    }
+
     let items = parse_ddg_html(&html, count);
     if items.is_empty() {
         return Ok(ToolResult::ok(
             "",
-            "No results found. (DDG returned no parseable results — it may be rate-limiting.)",
+            "No results found.",
         ));
     }
     Ok(ToolResult::ok("", items.join("\n\n")))

--- a/crates/garudust-tools/src/toolsets/web.rs
+++ b/crates/garudust-tools/src/toolsets/web.rs
@@ -407,10 +407,7 @@ async fn ddg_search(query: &str, count: usize) -> Result<ToolResult, ToolError> 
 
     let items = parse_ddg_html(&html, count);
     if items.is_empty() {
-        return Ok(ToolResult::ok(
-            "",
-            "No results found.",
-        ));
+        return Ok(ToolResult::ok("", "No results found."));
     }
     Ok(ToolResult::ok("", items.join("\n\n")))
 }


### PR DESCRIPTION
## Summary

- DDG returns HTTP 202 (or a 200 page containing `anomaly.js`) when it serves a CAPTCHA/bot-detection challenge instead of search results
- Previously the code accepted 202 as a successful 2xx, tried to parse the challenge HTML, found no `result__title`, and returned a vague "may be rate-limiting" message
- Now detects both the 202 status **and** the `anomaly.js` body fingerprint and returns a clear, actionable message directing the user to set `BRAVE_SEARCH_API_KEY`

## Root Cause

DuckDuckGo aggressively blocks programmatic requests from residential/server IPs, especially for non-English queries. The bot challenge page is served with HTTP 202 Accepted (not 403/429), so `is_success()` returned `true` and the code silently ate the failure.

## Test Plan

- [ ] Run `web_search` without `BRAVE_SEARCH_API_KEY` from an IP that DDG blocks — should now see the actionable message instead of "No results found"
- [ ] `cargo check -p garudust-tools` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)