### PR TITLE
feat: per-skill tool permissioning via SKILL.md frontmatter

### DIFF
--- a/crates/garudust-agent/src/agent.rs
+++ b/crates/garudust-agent/src/agent.rs
@@ -482,6 +482,9 @@ impl Agent {
                 config: self.config.clone(),
                 approver: approver.clone(),
                 sub_agent: Some(sub_agent),
+                skill_permissions: Arc::new(tokio::sync::RwLock::new(
+                    garudust_core::tool::SkillPermissions::default(),
+                )),
             });
 
             let tool_timeout_secs = self.config.tool_timeout_secs;
@@ -744,6 +747,9 @@ async fn reflect_and_save_skill(
             config: config.clone(),
             approver: Arc::new(crate::approver::AutoApprover),
             sub_agent: None,
+            skill_permissions: Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         };
         match tools
             .dispatch("write_skill", tc.arguments.clone(), &ctx)

--- a/crates/garudust-core/src/error.rs
+++ b/crates/garudust-core/src/error.rs
@@ -48,6 +48,8 @@ pub enum ToolError {
     Execution(String),
     #[error("approval denied")]
     ApprovalDenied,
+    #[error("tool '{0}' denied by active skill permissions")]
+    PermissionDenied(String),
     #[error("tool timed out after {0}s")]
     Timeout(u64),
     #[error(transparent)]

--- a/crates/garudust-core/src/tool.rs
+++ b/crates/garudust-core/src/tool.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
+use tokio::sync::RwLock;
 
 use crate::{
     budget::IterationBudget,
@@ -9,6 +10,31 @@ use crate::{
     memory::MemoryStore,
     types::{ToolResult, ToolSchema},
 };
+
+/// Accumulated permissions from all skills loaded in the current session.
+/// Each entry maps a tool name to `true` (allowed) or `false` (denied).
+/// Union semantics: `true` from any skill wins over `false` from another.
+/// Tools absent from the map are not restricted by skill permissions.
+#[derive(Debug, Default, Clone)]
+pub struct SkillPermissions(pub HashMap<String, bool>);
+
+impl SkillPermissions {
+    /// Merge another skill's permissions using union semantics (allow wins).
+    pub fn merge(&mut self, other: &HashMap<String, bool>) {
+        for (tool, allowed) in other {
+            let entry = self.0.entry(tool.clone()).or_insert(false);
+            if *allowed {
+                *entry = true;
+            }
+        }
+    }
+
+    /// Returns `Some(false)` only if the tool is explicitly denied by every
+    /// loaded skill that mentions it. Returns `None` if no skill restricts it.
+    pub fn check(&self, tool_name: &str) -> Option<bool> {
+        self.0.get(tool_name).copied()
+    }
+}
 
 #[async_trait]
 pub trait Tool: Send + Sync + 'static {
@@ -68,6 +94,9 @@ pub struct ToolContext {
     pub config: Arc<AgentConfig>,
     pub approver: Arc<dyn CommandApprover>,
     pub sub_agent: Option<Arc<dyn SubAgentRunner>>,
+    /// Accumulated permissions from all skills loaded this session via skill_view.
+    /// Shared across all tool dispatches within the same agent turn.
+    pub skill_permissions: Arc<RwLock<SkillPermissions>>,
 }
 
 #[async_trait]

--- a/crates/garudust-tools/src/registry.rs
+++ b/crates/garudust-tools/src/registry.rs
@@ -65,6 +65,13 @@ impl ToolRegistry {
             .get(name)
             .ok_or_else(|| ToolError::NotFound(name.into()))?;
 
+        // Check per-skill permissions before anything else.
+        if let Some(allowed) = ctx.skill_permissions.read().await.check(name) {
+            if !allowed {
+                return Err(ToolError::PermissionDenied(name.into()));
+            }
+        }
+
         // Validate params against the tool's declared JSON Schema.
         if let Some(validator) = self.validators.get(name) {
             let errors: Vec<String> = validator
@@ -248,6 +255,9 @@ mod tests {
             config: Arc::new(AgentConfig::default()),
             approver: Arc::new(DenyAll),
             sub_agent: None,
+            skill_permissions: Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         }
     }
 

--- a/crates/garudust-tools/src/toolsets/files.rs
+++ b/crates/garudust-tools/src/toolsets/files.rs
@@ -428,6 +428,9 @@ mod tests {
             config: Arc::new(config),
             approver: Arc::new(AutoApprove),
             sub_agent: None,
+            skill_permissions: std::sync::Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         }
     }
 
@@ -507,6 +510,9 @@ mod tests {
             config: Arc::new(config),
             approver: Arc::new(AutoApprove),
             sub_agent: None,
+            skill_permissions: std::sync::Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         };
 
         let result = ReadFile
@@ -541,6 +547,9 @@ mod tests {
             config: Arc::new(config),
             approver: Arc::new(AutoApprove),
             sub_agent: None,
+            skill_permissions: std::sync::Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         };
 
         let result = ReadFile

--- a/crates/garudust-tools/src/toolsets/memory.rs
+++ b/crates/garudust-tools/src/toolsets/memory.rs
@@ -276,6 +276,9 @@ mod tests {
             config: Arc::new(AgentConfig::default()),
             approver: Arc::new(AutoApprove),
             sub_agent: None,
+            skill_permissions: std::sync::Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         }
     }
 

--- a/crates/garudust-tools/src/toolsets/skills.rs
+++ b/crates/garudust-tools/src/toolsets/skills.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::{collections::HashMap, path::{Path, PathBuf}};
 
 use async_trait::async_trait;
 use garudust_core::{
@@ -16,6 +16,9 @@ pub struct Skill {
     pub description: String,
     pub version: Option<String>,
     pub platforms: Option<Vec<String>>,
+    /// Optional per-skill tool permissions. Map of tool name → allowed.
+    /// Absent tools are not restricted. Union semantics when multiple skills loaded.
+    pub permissions: Option<HashMap<String, bool>>,
     pub body: String,
     pub path: PathBuf,
 }
@@ -46,12 +49,18 @@ pub fn parse_skill_md(content: &str, path: PathBuf) -> Option<Skill> {
             .filter_map(|v| v.as_str().map(str::to_string))
             .collect()
     });
+    let permissions = yaml["permissions"].as_mapping().map(|map| {
+        map.iter()
+            .filter_map(|(k, v)| Some((k.as_str()?.to_string(), v.as_bool()?)))
+            .collect()
+    });
 
     Some(Skill {
         name,
         description,
         version,
         platforms,
+        permissions,
         body,
         path,
     })
@@ -222,6 +231,10 @@ impl Tool for SkillView {
             .iter()
             .find(|s| s.name == name)
             .ok_or_else(|| ToolError::NotFound(format!("skill '{name}' not found")))?;
+
+        if let Some(perms) = &skill.permissions {
+            ctx.skill_permissions.write().await.merge(perms);
+        }
 
         Ok(ToolResult::ok(
             "",

--- a/crates/garudust-tools/src/toolsets/skills.rs
+++ b/crates/garudust-tools/src/toolsets/skills.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, path::{Path, PathBuf}};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use async_trait::async_trait;
 use garudust_core::{

--- a/crates/garudust-tools/src/toolsets/terminal.rs
+++ b/crates/garudust-tools/src/toolsets/terminal.rs
@@ -487,6 +487,9 @@ mod tests {
             config: Arc::new(config),
             approver: Arc::new(AutoApprove),
             sub_agent: None,
+            skill_permissions: std::sync::Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         }
     }
 

--- a/crates/garudust-tools/src/toolsets/web.rs
+++ b/crates/garudust-tools/src/toolsets/web.rs
@@ -592,6 +592,9 @@ mod tests {
             config: Arc::new(AgentConfig::default()),
             approver: Arc::new(AutoApprove),
             sub_agent: None,
+            skill_permissions: std::sync::Arc::new(tokio::sync::RwLock::new(
+                garudust_core::tool::SkillPermissions::default(),
+            )),
         }
     }
 


### PR DESCRIPTION
Closes #96

## Summary

- Add `permissions:` block to `SKILL.md` frontmatter — skills can now declare which tools they allow or deny
- `SkillPermissions` type in `garudust-core` with union-semantics merge (allow wins across multiple loaded skills)
- `ToolRegistry::dispatch()` checks permissions before validation or approval gate
- `ToolError::PermissionDenied` variant for clear error reporting
- Zero behaviour change for existing skills without a `permissions:` block

## Example

```markdown
---
name: research-only
description: Read-only research skill
permissions:
  web_search: true
  web_fetch: true
  terminal: false
  write_file: false
---
```

## Test plan

- [ ] Build passes: `cargo build --workspace`
- [ ] Clippy clean: `cargo clippy --workspace --all-targets -- -W clippy::all -W clippy::pedantic`
- [ ] Tests pass: `cargo test --workspace`
- [ ] Skill without `permissions:` block behaves identically to before
- [ ] Skill with `terminal: false` — calling terminal after `skill_view` returns `PermissionDenied`
- [ ] Two skills loaded: one `terminal: false`, other `terminal: true` — terminal allowed (union wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)