### PR TITLE
feat(platforms): add WhatsApp Business Cloud API adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
  "futures",
  "garudust-agent",
  "garudust-core",
+ "hex",
  "hmac 0.13.0",
  "matrix-sdk",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ dashmap   = "6"
 hmac      = "0.13"
 sha2      = "0.11"
 base64    = "0.22"
+hex       = "0.4"
 
 # JSON Schema validation
 jsonschema = { version = "0.46", default-features = false }

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -11,7 +11,7 @@ use garudust_gateway::{create_router, AppState, GatewayHandler, Metrics, Session
 use garudust_memory::{FileMemoryStore, SessionDb};
 use garudust_platforms::{
     discord::DiscordAdapter, line::LineAdapter, matrix::MatrixAdapter, slack::SlackAdapter,
-    telegram::TelegramAdapter, webhook::WebhookAdapter,
+    telegram::TelegramAdapter, webhook::WebhookAdapter, whatsapp::WhatsAppAdapter,
 };
 use garudust_tools::{
     security::docker_available,
@@ -90,6 +90,24 @@ struct Cli {
     /// Port for the LINE webhook receiver (0 = disabled)
     #[arg(long, env = "GARUDUST_LINE_PORT", default_value = "3002")]
     line_port: u16,
+
+    #[arg(long, env = "WHATSAPP_ACCESS_TOKEN")]
+    whatsapp_access_token: Option<String>,
+
+    #[arg(long, env = "WHATSAPP_PHONE_NUMBER_ID")]
+    whatsapp_phone_number_id: Option<String>,
+
+    /// WhatsApp app secret for HMAC signature verification (leave empty to skip verification)
+    #[arg(long, env = "WHATSAPP_APP_SECRET", default_value = "")]
+    whatsapp_app_secret: String,
+
+    /// Token used during Meta webhook verification handshake
+    #[arg(long, env = "WHATSAPP_VERIFY_TOKEN", default_value = "")]
+    whatsapp_verify_token: String,
+
+    /// Port for the WhatsApp webhook receiver (0 = disabled)
+    #[arg(long, env = "GARUDUST_WHATSAPP_PORT", default_value = "3003")]
+    whatsapp_port: u16,
 
     /// Comma-separated list of cron jobs: "cron_expr=task" pairs
     /// e.g. "0 9 * * *=Good morning report"
@@ -429,6 +447,28 @@ async fn main() -> Result<()> {
                 token.clone(),
                 secret.clone(),
                 cli.line_port,
+            ));
+            start_platform(
+                platform,
+                agent.load_full(),
+                sessions.clone(),
+                approver.clone(),
+                config.clone(),
+            )
+            .await?;
+        }
+    }
+
+    if let (Some(token), Some(phone_id)) =
+        (&cli.whatsapp_access_token, &cli.whatsapp_phone_number_id)
+    {
+        if cli.whatsapp_port > 0 {
+            let platform: Arc<dyn PlatformAdapter> = Arc::new(WhatsAppAdapter::new(
+                token.clone(),
+                phone_id.clone(),
+                cli.whatsapp_app_secret.clone(),
+                cli.whatsapp_verify_token.clone(),
+                cli.whatsapp_port,
             ));
             start_platform(
                 platform,

--- a/bin/garudust/src/setup.rs
+++ b/bin/garudust/src/setup.rs
@@ -35,6 +35,21 @@ const PLATFORMS: &[(&str, &[(&str, &str)])] = &[
             ("LINE channel secret", "LINE_CHANNEL_SECRET"),
         ],
     ),
+    (
+        "WhatsApp",
+        &[
+            ("WhatsApp access token", "WHATSAPP_ACCESS_TOKEN"),
+            ("WhatsApp phone number ID", "WHATSAPP_PHONE_NUMBER_ID"),
+            (
+                "WhatsApp app secret (for signature verification)",
+                "WHATSAPP_APP_SECRET",
+            ),
+            (
+                "WhatsApp verify token (for webhook setup)",
+                "WHATSAPP_VERIFY_TOKEN",
+            ),
+        ],
+    ),
 ];
 
 pub async fn run() -> anyhow::Result<()> {
@@ -316,6 +331,9 @@ fn validate_token(var: &str, val: &str) -> Option<&'static str> {
         }
         "LINE_CHANNEL_SECRET" if val.len() != 32 || !val.chars().all(|c| c.is_ascii_hexdigit()) => {
             return Some("expected format: 32-character hex string");
+        }
+        "WHATSAPP_PHONE_NUMBER_ID" if !val.chars().all(|c| c.is_ascii_digit()) => {
+            return Some("expected format: numeric ID (e.g. 123456789012345)");
         }
         _ => {}
     }

--- a/crates/garudust-platforms/Cargo.toml
+++ b/crates/garudust-platforms/Cargo.toml
@@ -19,7 +19,8 @@ webhook  = ["dep:axum"]
 slack    = ["dep:tokio-tungstenite"]
 matrix   = ["dep:matrix-sdk"]
 line     = ["dep:hmac", "dep:sha2", "dep:base64", "dep:axum", "dep:dashmap"]
-all      = ["telegram", "discord", "webhook", "slack", "matrix", "line"]
+whatsapp = ["dep:hmac", "dep:sha2", "dep:hex", "dep:axum"]
+all      = ["telegram", "discord", "webhook", "slack", "matrix", "line", "whatsapp"]
 
 [dependencies]
 garudust-core  = { path = "../garudust-core",  version = "0.2.1" }
@@ -42,3 +43,4 @@ dashmap           = { workspace = true, optional = true }
 hmac              = { workspace = true, optional = true }
 sha2              = { workspace = true, optional = true }
 base64            = { workspace = true, optional = true }
+hex               = { workspace = true, optional = true }

--- a/crates/garudust-platforms/src/lib.rs
+++ b/crates/garudust-platforms/src/lib.rs
@@ -49,3 +49,6 @@ pub mod matrix;
 
 #[cfg(feature = "line")]
 pub mod line;
+
+#[cfg(feature = "whatsapp")]
+pub mod whatsapp;

--- a/crates/garudust-platforms/src/whatsapp.rs
+++ b/crates/garudust-platforms/src/whatsapp.rs
@@ -108,9 +108,8 @@ fn verify_sig(app_secret: &str, body: &[u8], header: &str) -> bool {
     let Ok(expected_bytes) = hex::decode(expected) else {
         return false;
     };
-    let mut mac = match Hmac::<Sha256>::new_from_slice(app_secret.as_bytes()) {
-        Ok(m) => m,
-        Err(_) => return false,
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(app_secret.as_bytes()) else {
+        return false;
     };
     mac.update(body);
     mac.verify_slice(&expected_bytes).is_ok()
@@ -190,8 +189,7 @@ async fn handle_webhook(
                 let user_name = contacts
                     .iter()
                     .find(|c| c.wa_id == wa_id)
-                    .map(|c| c.profile.name.clone())
-                    .unwrap_or_else(|| wa_id.clone());
+                    .map_or_else(|| wa_id.clone(), |c| c.profile.name.clone());
 
                 let inbound = InboundMessage {
                     channel: ChannelId {

--- a/crates/garudust-platforms/src/whatsapp.rs
+++ b/crates/garudust-platforms/src/whatsapp.rs
@@ -1,0 +1,389 @@
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::{
+    body::Bytes,
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use hmac::{Hmac, KeyInit, Mac};
+use serde::Deserialize;
+use serde_json::json;
+use sha2::Sha256;
+use tokio::net::TcpListener;
+
+use futures::Stream;
+use garudust_core::{
+    error::PlatformError,
+    platform::{MessageHandler, PlatformAdapter},
+    types::{ChannelId, InboundMessage, OutboundMessage},
+};
+
+const WHATSAPP_API_URL: &str = "https://graph.facebook.com/v20.0";
+/// WhatsApp Cloud API text message limit.
+const WA_TEXT_LIMIT: usize = 4_096;
+
+// ── WhatsApp Cloud API webhook deserialization ────────────────────────────────
+
+#[derive(Deserialize)]
+struct WebhookPayload {
+    entry: Vec<Entry>,
+}
+
+#[derive(Deserialize)]
+struct Entry {
+    changes: Vec<Change>,
+}
+
+#[derive(Deserialize)]
+struct Change {
+    value: ChangeValue,
+}
+
+#[derive(Deserialize)]
+struct ChangeValue {
+    contacts: Option<Vec<Contact>>,
+    messages: Option<Vec<WaMessage>>,
+}
+
+#[derive(Deserialize)]
+struct Contact {
+    #[serde(rename = "wa_id")]
+    wa_id: String,
+    profile: Profile,
+}
+
+#[derive(Deserialize)]
+struct Profile {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct WaMessage {
+    from: String,
+    #[serde(rename = "type")]
+    kind: String,
+    text: Option<WaText>,
+}
+
+#[derive(Deserialize)]
+struct WaText {
+    body: String,
+}
+
+// ── Webhook verification ──────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct VerifyParams {
+    #[serde(rename = "hub.mode")]
+    mode: String,
+    #[serde(rename = "hub.verify_token")]
+    verify_token: String,
+    #[serde(rename = "hub.challenge")]
+    challenge: String,
+}
+
+// ── Shared state ──────────────────────────────────────────────────────────────
+
+struct Inner {
+    access_token: String,
+    phone_number_id: String,
+    app_secret: String,
+    verify_token: String,
+    client: reqwest::Client,
+}
+
+struct WhatsAppState {
+    inner: Arc<Inner>,
+    handler: Arc<dyn MessageHandler>,
+}
+
+// ── Signature verification ────────────────────────────────────────────────────
+
+fn verify_sig(app_secret: &str, body: &[u8], header: &str) -> bool {
+    let expected = header.strip_prefix("sha256=").unwrap_or("");
+    let Ok(expected_bytes) = hex::decode(expected) else {
+        return false;
+    };
+    let mut mac = match Hmac::<Sha256>::new_from_slice(app_secret.as_bytes()) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    mac.update(body);
+    mac.verify_slice(&expected_bytes).is_ok()
+}
+
+// ── Text chunking ─────────────────────────────────────────────────────────────
+
+fn chunk_text(text: &str) -> Vec<String> {
+    if text.len() <= WA_TEXT_LIMIT {
+        return vec![text.to_string()];
+    }
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let end = (start + WA_TEXT_LIMIT).min(text.len());
+        // Walk back to a char boundary
+        let end = (start..=end)
+            .rev()
+            .find(|&i| text.is_char_boundary(i))
+            .unwrap_or(end);
+        chunks.push(text[start..end].to_string());
+        start = end;
+    }
+    chunks
+}
+
+// ── Axum handlers ─────────────────────────────────────────────────────────────
+
+async fn handle_verify(
+    State(state): State<Arc<WhatsAppState>>,
+    Query(params): Query<VerifyParams>,
+) -> Result<String, StatusCode> {
+    if params.mode == "subscribe" && params.verify_token == state.inner.verify_token {
+        tracing::info!("WhatsApp: webhook verified");
+        Ok(params.challenge)
+    } else {
+        tracing::warn!("WhatsApp: webhook verification failed — token mismatch");
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+async fn handle_webhook(
+    State(state): State<Arc<WhatsAppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    let sig = headers
+        .get("x-hub-signature-256")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !state.inner.app_secret.is_empty() && !verify_sig(&state.inner.app_secret, &body, sig) {
+        tracing::warn!("WhatsApp: rejected webhook — invalid signature");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let Ok(payload) = serde_json::from_slice::<WebhookPayload>(&body) else {
+        return StatusCode::BAD_REQUEST;
+    };
+
+    for entry in payload.entry {
+        for change in entry.changes {
+            let value = change.value;
+            let Some(messages) = value.messages else {
+                continue;
+            };
+            let contacts = value.contacts.unwrap_or_default();
+
+            for msg in messages {
+                if msg.kind != "text" {
+                    continue;
+                }
+                let Some(text_obj) = msg.text else { continue };
+                let text = text_obj.body;
+                let wa_id = msg.from.clone();
+
+                let user_name = contacts
+                    .iter()
+                    .find(|c| c.wa_id == wa_id)
+                    .map(|c| c.profile.name.clone())
+                    .unwrap_or_else(|| wa_id.clone());
+
+                let inbound = InboundMessage {
+                    channel: ChannelId {
+                        platform: "whatsapp".into(),
+                        chat_id: wa_id.clone(),
+                        thread_id: None,
+                    },
+                    user_id: wa_id.clone(),
+                    user_name,
+                    text,
+                    session_key: format!("whatsapp:{wa_id}"),
+                    is_group: false,
+                };
+
+                let handler = state.handler.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handler.handle(inbound).await {
+                        tracing::error!(wa_id, "WhatsApp: handler error: {e}");
+                    }
+                });
+            }
+        }
+    }
+
+    StatusCode::OK
+}
+
+// ── Adapter ───────────────────────────────────────────────────────────────────
+
+pub struct WhatsAppAdapter {
+    port: u16,
+    inner: Arc<Inner>,
+}
+
+impl WhatsAppAdapter {
+    /// Create a new adapter.
+    ///
+    /// * `access_token`    — WhatsApp Cloud API access token
+    /// * `phone_number_id` — Phone number ID from the Meta developer console
+    /// * `app_secret`      — App secret for HMAC signature verification (pass empty string to skip)
+    /// * `verify_token`    — Token used during webhook verification
+    /// * `port`            — Local port to listen on for incoming webhooks
+    pub fn new(
+        access_token: String,
+        phone_number_id: String,
+        app_secret: String,
+        verify_token: String,
+        port: u16,
+    ) -> Self {
+        Self {
+            port,
+            inner: Arc::new(Inner {
+                access_token,
+                phone_number_id,
+                app_secret,
+                verify_token,
+                client: reqwest::Client::new(),
+            }),
+        }
+    }
+
+    async fn do_send(&self, to: &str, text: &str) -> Result<(), PlatformError> {
+        let url = format!("{WHATSAPP_API_URL}/{}/messages", self.inner.phone_number_id);
+
+        for chunk in chunk_text(text) {
+            let body = json!({
+                "messaging_product": "whatsapp",
+                "to": to,
+                "type": "text",
+                "text": { "body": chunk }
+            });
+
+            let resp = self
+                .inner
+                .client
+                .post(&url)
+                .bearer_auth(&self.inner.access_token)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| PlatformError::Send(e.to_string()))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let detail = resp.text().await.unwrap_or_default();
+                return Err(PlatformError::Send(format!(
+                    "WhatsApp API error {status}: {detail}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PlatformAdapter for WhatsAppAdapter {
+    fn name(&self) -> &'static str {
+        "whatsapp"
+    }
+
+    async fn start(&self, handler: Arc<dyn MessageHandler>) -> Result<(), PlatformError> {
+        let state = Arc::new(WhatsAppState {
+            inner: self.inner.clone(),
+            handler,
+        });
+
+        let router = Router::new()
+            .route("/whatsapp", get(handle_verify))
+            .route("/whatsapp", post(handle_webhook))
+            .with_state(state);
+
+        let port = self.port;
+        let listener = TcpListener::bind(format!("0.0.0.0:{port}"))
+            .await
+            .map_err(|e| PlatformError::Connection(e.to_string()))?;
+
+        tracing::info!("WhatsApp adapter listening on 0.0.0.0:{port}");
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, router).await {
+                tracing::error!("WhatsApp server error: {e}");
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        channel: &ChannelId,
+        message: OutboundMessage,
+    ) -> Result<(), PlatformError> {
+        self.do_send(&channel.chat_id, &message.text).await
+    }
+
+    async fn send_stream(
+        &self,
+        channel: &ChannelId,
+        mut stream: Pin<Box<dyn Stream<Item = String> + Send>>,
+    ) -> Result<(), PlatformError> {
+        use futures::StreamExt;
+        let mut buf = String::new();
+        while let Some(chunk) = stream.next().await {
+            buf.push_str(&chunk);
+        }
+        self.send_message(channel, OutboundMessage::text(buf)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_short_text_unchanged() {
+        let text = "hello";
+        let chunks = chunk_text(text);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], text);
+    }
+
+    #[test]
+    fn chunk_long_text_splits_on_char_boundary() {
+        let text = "あ".repeat(2000); // each char is 3 bytes → 6000 bytes total
+        let chunks = chunk_text(&text);
+        assert!(chunks.len() > 1);
+        for chunk in &chunks {
+            assert!(chunk.len() <= WA_TEXT_LIMIT);
+        }
+        assert_eq!(chunks.join(""), text);
+    }
+
+    #[test]
+    fn verify_sig_rejects_bad_signature() {
+        assert!(!verify_sig("secret", b"body", "sha256=badhex"));
+    }
+
+    #[test]
+    fn verify_sig_accepts_correct_signature() {
+        use hmac::Mac;
+        let secret = "mysecret";
+        let body = b"test body";
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let result = mac.finalize().into_bytes();
+        let hex_sig = format!("sha256={}", hex::encode(result));
+        assert!(verify_sig(secret, body, &hex_sig));
+    }
+
+    #[test]
+    fn verify_sig_rejects_bad_hex_when_secret_nonempty() {
+        // Non-matching signature must fail even with a valid secret
+        assert!(!verify_sig("secret", b"body", "sha256=00000000"));
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `WhatsAppAdapter` using the Meta Cloud API v20.0 (official WhatsApp Business API)
- Webhook `GET /whatsapp` handles Meta verification handshake (`hub.challenge` flow)
- Webhook `POST /whatsapp` receives inbound text messages with HMAC-SHA256 signature verification
- Outbound via `graph.facebook.com/{phone_number_id}/messages`, auto-chunks messages at 4 096-char boundary (respects multi-byte chars)
- Feature flag `whatsapp` — deps: `axum`, `hmac`, `sha2`, `hex`
- `garudust-server`: new env vars `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_APP_SECRET`, `WHATSAPP_VERIFY_TOKEN`, `GARUDUST_WHATSAPP_PORT` (default 3003)
- `garudust setup`: WhatsApp added to platform selector with numeric validation for `WHATSAPP_PHONE_NUMBER_ID`

Closes #27

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] Manual: set env vars, run `garudust-server`, configure Meta webhook to `https://your-host:3003/whatsapp`, send a test message

🤖 Generated with [Claude Code](https://claude.com/claude-code)