### PR TITLE
feat(tools): add delegate_tasks for parallel sub-agent execution

### DIFF
--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -17,7 +17,7 @@ use garudust_tools::{
     security::docker_available,
     toolsets::{
         browser::BrowserTool,
-        delegate::DelegateTask,
+        delegate::{DelegateTask, DelegateTasks},
         files::{ListDirectory, ReadFile, WriteFile},
         mcp::connect_mcp_server,
         memory::{MemoryTool, UserProfileTool},
@@ -191,6 +191,7 @@ async fn build_agent(config: Arc<AgentConfig>, db: Arc<SessionDb>) -> (Arc<Agent
     registry.register(SkillView);
     registry.register(WriteSkill);
     registry.register(DelegateTask);
+    registry.register(DelegateTasks);
     registry.register(BrowserTool::new());
 
     let mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -15,7 +15,7 @@ use garudust_tools::{
     security::docker_available,
     toolsets::{
         browser::BrowserTool,
-        delegate::DelegateTask,
+        delegate::{DelegateTask, DelegateTasks},
         files::{ListDirectory, ReadFile, WriteFile},
         mcp::connect_mcp_server,
         memory::{MemoryTool, UserProfileTool},
@@ -149,6 +149,7 @@ async fn build_agent(config: Arc<AgentConfig>) -> (Arc<Agent>, McpHandles) {
     registry.register(SkillView);
     registry.register(WriteSkill);
     registry.register(DelegateTask);
+    registry.register(DelegateTasks);
     registry.register(BrowserTool::new());
 
     let mcp_handles = attach_mcp_servers(&mut registry, &config.mcp_servers).await;

--- a/crates/garudust-tools/src/toolsets/delegate.rs
+++ b/crates/garudust-tools/src/toolsets/delegate.rs
@@ -1,12 +1,15 @@
 use async_trait::async_trait;
+use futures::future;
 use garudust_core::{
     error::ToolError,
     tool::{Tool, ToolContext},
     types::ToolResult,
 };
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 pub struct DelegateTask;
+pub struct DelegateTasks;
 
 #[async_trait]
 impl Tool for DelegateTask {
@@ -66,5 +69,139 @@ impl Tool for DelegateTask {
             .map_err(|e| ToolError::Execution(e.to_string()))?;
 
         Ok(ToolResult::ok("delegate_task", output))
+    }
+}
+
+// ── Parallel delegation ───────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct SubTask {
+    task: String,
+    #[serde(default)]
+    context: String,
+}
+
+#[async_trait]
+impl Tool for DelegateTasks {
+    fn name(&self) -> &'static str {
+        "delegate_tasks"
+    }
+
+    fn description(&self) -> &'static str {
+        "Spawn multiple sub-agents and run all tasks in parallel, returning each \
+         result when all have finished. Use this when the tasks are independent \
+         of each other — it is significantly faster than calling delegate_task \
+         one at a time. Each sub-agent gets the full tool set and its own \
+         iteration budget."
+    }
+
+    fn toolset(&self) -> &'static str {
+        "agent"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "description": "List of independent tasks to run in parallel.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "task": {
+                                "type": "string",
+                                "description": "Complete, self-contained task description."
+                            },
+                            "context": {
+                                "type": "string",
+                                "description": "Optional background context for this sub-task."
+                            }
+                        },
+                        "required": ["task"]
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": ["tasks"]
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let sub_tasks: Vec<SubTask> = serde_json::from_value(params["tasks"].clone())
+            .map_err(|e| ToolError::InvalidArgs(format!("'tasks' must be an array: {e}")))?;
+
+        if sub_tasks.is_empty() {
+            return Err(ToolError::InvalidArgs(
+                "'tasks' must contain at least one item".into(),
+            ));
+        }
+
+        let runner = ctx
+            .sub_agent
+            .as_ref()
+            .ok_or_else(|| ToolError::Execution("sub-agent runner not available".into()))?;
+
+        let futures: Vec<_> = sub_tasks
+            .iter()
+            .enumerate()
+            .map(|(i, st)| {
+                let full_task = if st.context.is_empty() {
+                    st.task.clone()
+                } else {
+                    format!("Context:\n{}\n\nTask:\n{}", st.context, st.task)
+                };
+                let runner = runner.clone();
+                let session_id = ctx.session_id.clone();
+                async move {
+                    let result = runner
+                        .run_task(&full_task, &session_id)
+                        .await
+                        .map_err(|e| ToolError::Execution(e.to_string()))?;
+                    Ok::<(usize, String), ToolError>((i, result))
+                }
+            })
+            .collect();
+
+        let results = future::join_all(futures).await;
+
+        let mut outputs: Vec<(usize, String)> =
+            results.into_iter().collect::<Result<Vec<_>, _>>()?;
+        outputs.sort_by_key(|(i, _)| *i);
+
+        let combined = outputs
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_, out))| format!("## Task {} result\n\n{out}", i + 1))
+            .collect::<Vec<_>>()
+            .join("\n\n---\n\n");
+
+        Ok(ToolResult::ok("delegate_tasks", combined))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_requires_tasks_array() {
+        let schema = DelegateTasks.schema();
+        assert_eq!(schema["required"][0], "tasks");
+        assert_eq!(schema["properties"]["tasks"]["type"], "array");
+    }
+
+    #[test]
+    fn subtask_deserializes_without_context() {
+        let v: SubTask = serde_json::from_str(r#"{"task":"do something"}"#).unwrap();
+        assert_eq!(v.task, "do something");
+        assert!(v.context.is_empty());
+    }
+
+    #[test]
+    fn subtask_deserializes_with_context() {
+        let v: SubTask =
+            serde_json::from_str(r#"{"task":"do something","context":"bg info"}"#).unwrap();
+        assert_eq!(v.context, "bg info");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `delegate_tasks` tool alongside the existing `delegate_task`
- Accepts an array of independent sub-tasks, runs all concurrently via `futures::future::join_all`
- Results are collected in original submission order and returned with `## Task N result` headers
- Registered in both `garudust` CLI and `garudust-server`
- 3 unit tests cover schema validation and `SubTask` deserialization

## When to use

Use `delegate_tasks` when the overall goal can be split into independent sub-tasks — it is significantly faster than calling `delegate_task` one at a time because all sub-agents run in parallel.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p garudust-tools` — 92 tests pass
- [x] `cargo clippy --workspace --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)