### PR TITLE
feat: per-task token budget and usage footer

### DIFF
--- a/crates/garudust-agent/src/agent.rs
+++ b/crates/garudust-agent/src/agent.rs
@@ -7,6 +7,7 @@ use garudust_core::{
     config::AgentConfig,
     error::AgentError,
     memory::MemoryStore,
+    pricing::usage_footer,
     tool::{SubAgentRunner, ToolContext},
     transport::ProviderTransport,
     types::{
@@ -403,6 +404,31 @@ impl Agent {
             total_in += resp.usage.input_tokens;
             total_out += resp.usage.output_tokens;
 
+            // Token budget: stop early if the per-task cap is reached.
+            if let Some(cap) = self.config.max_tokens_per_task {
+                let used = total_in + total_out;
+                if used >= cap {
+                    warn!(used, cap, "token budget exhausted — stopping task early");
+                    let footer = usage_footer(&self.config.model, iters, total_in, total_out);
+                    let output = format!(
+                        "[Token budget of {cap} exceeded after {used} tokens — \
+                         stopping early.]\n\n{footer}"
+                    );
+                    let result = AgentResult {
+                        output,
+                        usage: garudust_core::types::TokenUsage {
+                            input_tokens: total_in,
+                            output_tokens: total_out,
+                            ..Default::default()
+                        },
+                        iterations: iters,
+                        session_id: session_id.clone(),
+                    };
+                    self.persist_session(&session_id, platform, started_at, &history, &result);
+                    return Ok(result);
+                }
+            }
+
             history.push(Message {
                 role: Role::Assistant,
                 content: resp.content.clone(),
@@ -422,7 +448,9 @@ impl Agent {
                     .collect::<Vec<_>>()
                     .join("\n");
                 // Scrub any <recalled_memory> block the model may have echoed back.
-                let output = scrub_recalled_memory(&raw_output);
+                let raw_output = scrub_recalled_memory(&raw_output);
+                let footer = usage_footer(&self.config.model, iters, total_in, total_out);
+                let output = format!("{raw_output}\n\n{footer}");
 
                 let result = AgentResult {
                     output,

--- a/crates/garudust-agent/src/tests.rs
+++ b/crates/garudust-agent/src/tests.rs
@@ -138,7 +138,11 @@ async fn run_returns_reply() {
         .run("say hi", Arc::new(AutoApprove), "test")
         .await
         .unwrap();
-    assert_eq!(result.output, "Hello, world!");
+    assert!(
+        result.output.starts_with("Hello, world!"),
+        "unexpected output: {}",
+        result.output
+    );
     assert_eq!(result.iterations, 1);
 }
 
@@ -157,5 +161,9 @@ async fn run_streaming_emits_chunks() {
         chunks.push(c);
     }
     assert_eq!(chunks.join(""), "streamed response");
-    assert_eq!(result.output, "streamed response");
+    assert!(
+        result.output.starts_with("streamed response"),
+        "unexpected output: {}",
+        result.output
+    );
 }

--- a/crates/garudust-core/src/config.rs
+++ b/crates/garudust-core/src/config.rs
@@ -86,6 +86,11 @@ pub struct AgentConfig {
     /// requests to complete before forcing exit. Default: 30.
     #[serde(default = "default_shutdown_timeout_secs")]
     pub shutdown_timeout_secs: u64,
+    /// Hard cap on total tokens (input + output) consumed by a single task.
+    /// When exceeded the agent stops and returns what it has with a budget notice.
+    /// `None` means no limit.
+    #[serde(default)]
+    pub max_tokens_per_task: Option<u32>,
 }
 
 fn default_nudge_interval() -> u32 {
@@ -311,6 +316,7 @@ impl Default for AgentConfig {
             llm_timeout_secs: default_llm_timeout_secs(),
             tool_timeout_secs: default_tool_timeout_secs(),
             shutdown_timeout_secs: default_shutdown_timeout_secs(),
+            max_tokens_per_task: None,
         }
     }
 }

--- a/crates/garudust-core/src/error.rs
+++ b/crates/garudust-core/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum AgentError {
     #[error("budget exhausted after {0} iterations")]
     BudgetExhausted(u32),
+    #[error("token budget exhausted: {0} tokens used")]
+    TokenBudgetExhausted(u32),
     #[error("transport error: {0}")]
     Transport(#[from] TransportError),
     #[error("tool error: {0}")]

--- a/crates/garudust-core/src/lib.rs
+++ b/crates/garudust-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod memory;
 pub mod net_guard;
 pub mod platform;
+pub mod pricing;
 pub mod tool;
 pub mod transport;
 pub mod types;

--- a/crates/garudust-core/src/pricing.rs
+++ b/crates/garudust-core/src/pricing.rs
@@ -1,0 +1,152 @@
+/// Per-million-token prices (USD) for known models.
+/// Prices are approximate and updated manually. Models not listed here return `None`.
+struct ModelPrice {
+    input_per_m: f64,
+    output_per_m: f64,
+}
+
+fn lookup(model: &str) -> Option<ModelPrice> {
+    // Normalise: strip provider prefix ("anthropic/claude-...") and minor version suffixes.
+    let name = model
+        .rsplit_once('/')
+        .map(|(_, n)| n)
+        .unwrap_or(model)
+        .to_lowercase();
+
+    // Match by prefix so minor variants (e.g. -20251001) are covered.
+    let p = if name.starts_with("claude-opus-4") {
+        ModelPrice {
+            input_per_m: 15.0,
+            output_per_m: 75.0,
+        }
+    } else if name.starts_with("claude-sonnet-4") {
+        ModelPrice {
+            input_per_m: 3.0,
+            output_per_m: 15.0,
+        }
+    } else if name.starts_with("claude-haiku-4") {
+        ModelPrice {
+            input_per_m: 0.8,
+            output_per_m: 4.0,
+        }
+    } else if name.starts_with("claude-opus-3") {
+        ModelPrice {
+            input_per_m: 15.0,
+            output_per_m: 75.0,
+        }
+    } else if name.starts_with("claude-sonnet-3") {
+        ModelPrice {
+            input_per_m: 3.0,
+            output_per_m: 15.0,
+        }
+    } else if name.starts_with("claude-haiku-3") {
+        ModelPrice {
+            input_per_m: 0.25,
+            output_per_m: 1.25,
+        }
+    } else if name.starts_with("gpt-4o-mini") {
+        ModelPrice {
+            input_per_m: 0.15,
+            output_per_m: 0.60,
+        }
+    } else if name.starts_with("gpt-4o") {
+        ModelPrice {
+            input_per_m: 2.50,
+            output_per_m: 10.0,
+        }
+    } else if name.starts_with("gpt-4-turbo") || name.starts_with("gpt-4-1106") {
+        ModelPrice {
+            input_per_m: 10.0,
+            output_per_m: 30.0,
+        }
+    } else if name.starts_with("gpt-3.5") {
+        ModelPrice {
+            input_per_m: 0.50,
+            output_per_m: 1.50,
+        }
+    } else if name.starts_with("gemini-2.5-pro") {
+        ModelPrice {
+            input_per_m: 1.25,
+            output_per_m: 10.0,
+        }
+    } else if name.starts_with("gemini-2.5-flash") {
+        ModelPrice {
+            input_per_m: 0.15,
+            output_per_m: 0.60,
+        }
+    } else if name.starts_with("gemini-2.0-flash") {
+        ModelPrice {
+            input_per_m: 0.10,
+            output_per_m: 0.40,
+        }
+    } else if name.starts_with("gemini-1.5-pro") {
+        ModelPrice {
+            input_per_m: 3.50,
+            output_per_m: 10.50,
+        }
+    } else if name.starts_with("gemini-1.5-flash") {
+        ModelPrice {
+            input_per_m: 0.075,
+            output_per_m: 0.30,
+        }
+    } else {
+        return None;
+    };
+    Some(p)
+}
+
+/// Estimate USD cost for a completed task.
+/// Returns `None` if the model is not in the price table.
+pub fn estimate_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> Option<f64> {
+    let p = lookup(model)?;
+    let cost = (f64::from(input_tokens) / 1_000_000.0) * p.input_per_m
+        + (f64::from(output_tokens) / 1_000_000.0) * p.output_per_m;
+    Some(cost)
+}
+
+/// Format a usage footer line: `[N iter | Xin Yout tok | ~$Z @ model]`
+pub fn usage_footer(model: &str, iters: u32, input_tokens: u32, output_tokens: u32) -> String {
+    let total = input_tokens + output_tokens;
+    let cost_part = estimate_cost_usd(model, input_tokens, output_tokens)
+        .map(|c| format!(" | ~${c:.4}"))
+        .unwrap_or_default();
+    let short_model = model.rsplit_once('/').map(|(_, n)| n).unwrap_or(model);
+    format!(
+        "[{iters} iter | {input_tokens}in {output_tokens}out {total}tok{cost_part} @ {short_model}]"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_model_has_cost() {
+        let c = estimate_cost_usd("anthropic/claude-sonnet-4-6", 10_000, 2_000);
+        assert!(c.is_some());
+        // 10k in @ $3/M + 2k out @ $15/M = $0.030 + $0.030 = $0.060
+        let c = c.unwrap();
+        assert!((c - 0.060).abs() < 0.001, "expected ~$0.06, got {c}");
+    }
+
+    #[test]
+    fn unknown_model_returns_none() {
+        assert!(estimate_cost_usd("local/mistral-7b", 1000, 500).is_none());
+    }
+
+    #[test]
+    fn footer_includes_iter_and_tokens() {
+        let footer = usage_footer("claude-sonnet-4-6", 3, 1000, 500);
+        assert!(footer.contains("3 iter"));
+        assert!(footer.contains("1000in"));
+        assert!(footer.contains("500out"));
+        assert!(footer.contains("1500tok"));
+    }
+
+    #[test]
+    fn footer_strips_provider_prefix() {
+        let footer = usage_footer("anthropic/claude-haiku-4-5", 1, 100, 50);
+        assert!(footer.contains("@ claude-haiku-4-5"));
+        assert!(!footer.contains("anthropic/"));
+    }
+}

--- a/crates/garudust-core/src/pricing.rs
+++ b/crates/garudust-core/src/pricing.rs
@@ -9,8 +9,7 @@ fn lookup(model: &str) -> Option<ModelPrice> {
     // Normalise: strip provider prefix ("anthropic/claude-...") and minor version suffixes.
     let name = model
         .rsplit_once('/')
-        .map(|(_, n)| n)
-        .unwrap_or(model)
+        .map_or(model, |(_, n)| n)
         .to_lowercase();
 
     // Match by prefix so minor variants (e.g. -20251001) are covered.
@@ -110,7 +109,7 @@ pub fn usage_footer(model: &str, iters: u32, input_tokens: u32, output_tokens: u
     let cost_part = estimate_cost_usd(model, input_tokens, output_tokens)
         .map(|c| format!(" | ~${c:.4}"))
         .unwrap_or_default();
-    let short_model = model.rsplit_once('/').map(|(_, n)| n).unwrap_or(model);
+    let short_model = model.rsplit_once('/').map_or(model, |(_, n)| n);
     format!(
         "[{iters} iter | {input_tokens}in {output_tokens}out {total}tok{cost_part} @ {short_model}]"
     )


### PR DESCRIPTION
## Summary

- Adds `max_tokens_per_task: Option<u32>` to `AgentConfig` — when the cumulative input + output tokens for a task exceeds this cap, the agent stops the loop early and returns a budget-exceeded notice
- Every completed task now appends a one-line usage footer: `[N iter | Xin Yout Ztok | ~$cost @ model]`
- New `garudust-core::pricing` module with a static per-million-token price table covering Claude 3/4, GPT-4o/mini, and Gemini 1.5/2.x families
- `TokenBudgetExhausted` variant added to `AgentError` for future programmatic use

## Example footer

```
[5 iter | 12430in 3210out 15640tok | ~$0.0852 @ claude-sonnet-4-6]
```

## Config

```yaml
# ~/.garudust/config.yaml
max_tokens_per_task: 50000   # hard stop when task exceeds 50K total tokens
```

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all pass (pricing: 4 tests, agent: 3 tests)
- [x] `cargo clippy --workspace --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — no diff

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)