### PR TITLE
docs: add Discord community link to all README languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Release](https://img.shields.io/github/v/release/garudust-org/garudust-agent)](https://github.com/garudust-org/garudust-agent/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![Rust 1.87+](https://img.shields.io/badge/rust-1.87+-orange.svg)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white&style=flat-square)](https://discord.com/channels/1501414298449088745/1501414298893942877)
 
 **A self-hostable, self-improving AI agent runtime written in Rust.**
 
@@ -508,6 +509,8 @@ cargo clippy --workspace --all-targets -- -W clippy::all -W clippy::pedantic
 ```
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) for code guidelines, commit conventions, and the full CI checklist.
+
+Have a question or found a bug? Join the [Discord community](https://discord.com/channels/1501414298449088745/1501414298893942877) or open a [GitHub issue](https://github.com/garudust-org/garudust-agent/issues).
 
 ---
 

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -14,6 +14,7 @@
 [![Release](https://img.shields.io/github/v/release/garudust-org/garudust-agent)](https://github.com/garudust-org/garudust-agent/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../../LICENSE)
 ![Rust 1.87+](https://img.shields.io/badge/rust-1.87+-orange.svg)
+[![Discord](https://img.shields.io/badge/Discord-ชุมชน-5865F2?logo=discord&logoColor=white&style=flat-square)](https://discord.com/channels/1501414298449088745/1501414298893942877)
 
 **ระบบรันไทม์ AI agent ที่โฮสต์เองได้ พัฒนาตัวเองได้ เขียนด้วย Rust**
 
@@ -509,6 +510,8 @@ cargo clippy --workspace --all-targets -- -W clippy::all -W clippy::pedantic
 ```
 
 อ่าน [CONTRIBUTING.md](../../../CONTRIBUTING.md) สำหรับแนวทางโค้ด, commit convention และ CI checklist ครบถ้วน
+
+มีคำถามหรือพบบัค? เข้าร่วม [ชุมชน Discord](https://discord.com/channels/1501414298449088745/1501414298893942877) หรือเปิด [GitHub issue](https://github.com/garudust-org/garudust-agent/issues)
 
 ---
 

--- a/docs/i18n/zh/README.md
+++ b/docs/i18n/zh/README.md
@@ -14,6 +14,7 @@
 [![Release](https://img.shields.io/github/v/release/garudust-org/garudust-agent)](https://github.com/garudust-org/garudust-agent/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../../LICENSE)
 ![Rust 1.87+](https://img.shields.io/badge/rust-1.87+-orange.svg)
+[![Discord](https://img.shields.io/badge/Discord-加入社区-5865F2?logo=discord&logoColor=white&style=flat-square)](https://discord.com/channels/1501414298449088745/1501414298893942877)
 
 **用 Rust 编写的可自托管、可自我进化的 AI 智能体运行时**
 
@@ -507,6 +508,8 @@ cargo clippy --workspace --all-targets -- -W clippy::all -W clippy::pedantic
 ```
 
 请阅读 [CONTRIBUTING.md](../../../CONTRIBUTING.md) 了解代码规范、提交约定和完整 CI 检查清单。
+
+有问题或发现 Bug？加入 [Discord 社区](https://discord.com/channels/1501414298449088745/1501414298893942877) 交流，或提交 [GitHub issue](https://github.com/garudust-org/garudust-agent/issues)。
 
 ---
 


### PR DESCRIPTION
## Summary

- Added Discord badge (shield.io) in the badge row of all three READMEs (EN, TH, ZH)
- Added a line in the Contributing section of each README pointing users to the Discord community for questions and bug reports
- Badge text is localized: `Join Community` / `ชุมชน` / `加入社区`

## Test plan

- [ ] Verify badge renders correctly on GitHub (shield.io Discord badge with purple color)
- [ ] Verify links open the correct Discord channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)