### PR TITLE
feat(cli): add garudust skill install/list/uninstall

### DIFF
--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -1,6 +1,7 @@
 mod config_cmd;
 mod doctor;
 mod setup;
+mod skill_cmd;
 mod tool_cmd;
 mod tui;
 
@@ -64,6 +65,30 @@ enum ToolCmd {
 }
 
 #[derive(Subcommand)]
+enum SkillCmd {
+    /// List installed skills
+    List,
+    /// Install a skill from GitHub, a direct URL, or a well-known endpoint
+    ///
+    /// Sources:
+    ///   owner/repo/path      — GitHub (raw.githubusercontent.com)
+    ///   https://…/SKILL.md   — direct URL
+    ///   well-known:https://… — /.well-known/skills/<name>/SKILL.md
+    Install {
+        /// Source (GitHub path, URL, or well-known prefix)
+        source: String,
+        /// Skill name to use when saving (inferred from source if omitted)
+        #[arg(long, default_value = "")]
+        name: String,
+    },
+    /// Remove an installed skill
+    Uninstall {
+        /// Skill name as shown in `garudust skill list`
+        name: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum Cmd {
     /// Interactive first-time setup wizard
     Setup,
@@ -87,6 +112,12 @@ enum Cmd {
     Tool {
         #[command(subcommand)]
         sub: ToolCmd,
+    },
+
+    /// Manage skills (install, uninstall, list)
+    Skill {
+        #[command(subcommand)]
+        sub: SkillCmd,
     },
 }
 
@@ -253,6 +284,24 @@ async fn main() -> Result<()> {
                 }
                 ToolCmd::Update { name } => {
                     tool_cmd::update(name.as_deref(), &tools_dir).await?;
+                }
+            }
+            return Ok(());
+        }
+
+        Some(Cmd::Skill { sub }) => {
+            let config = build_config(&cli);
+            let skills_dir = config.home_dir.join("skills");
+            tokio::fs::create_dir_all(&skills_dir).await?;
+            match sub {
+                SkillCmd::List => {
+                    skill_cmd::list(&skills_dir).await?;
+                }
+                SkillCmd::Install { source, name } => {
+                    skill_cmd::install(source, name, &skills_dir).await?;
+                }
+                SkillCmd::Uninstall { name } => {
+                    skill_cmd::uninstall(name, &skills_dir).await?;
                 }
             }
             return Ok(());

--- a/bin/garudust/src/skill_cmd.rs
+++ b/bin/garudust/src/skill_cmd.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use anyhow::Result;
+use garudust_tools::skill_hub;
+
+pub async fn list(skills_dir: &Path) -> Result<()> {
+    let skills = skill_hub::list_installed(skills_dir).await;
+
+    if skills.is_empty() {
+        println!(
+            "No skills installed. Run `garudust skill install <source>` to install one.\n\
+             Sources: owner/repo/path  |  https://…/SKILL.md  |  well-known:https://…"
+        );
+        return Ok(());
+    }
+
+    let name_w = skills
+        .iter()
+        .map(|s| s.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let ver_w = 9usize;
+
+    println!("{:<name_w$}  {:<ver_w$}  DESCRIPTION", "NAME", "VERSION");
+    println!("{}", "-".repeat(name_w + ver_w + 16));
+
+    for s in &skills {
+        let desc = if s.description.chars().count() > 56 {
+            format!("{}…", s.description.chars().take(55).collect::<String>())
+        } else {
+            s.description.clone()
+        };
+        println!("{:<name_w$}  {:<ver_w$}  {desc}", s.name, s.version);
+    }
+
+    Ok(())
+}
+
+pub async fn install(source: &str, name: &str, skills_dir: &Path) -> Result<()> {
+    println!("Installing skill from '{source}'...");
+    let installed_name = skill_hub::install_skill(source, name, skills_dir).await?;
+    println!("Installed skill '{installed_name}'.");
+    Ok(())
+}
+
+pub async fn uninstall(skill_name: &str, skills_dir: &Path) -> Result<()> {
+    skill_hub::uninstall_skill(skill_name, skills_dir).await?;
+    println!("Uninstalled skill '{skill_name}'.");
+    Ok(())
+}

--- a/crates/garudust-tools/src/lib.rs
+++ b/crates/garudust-tools/src/lib.rs
@@ -23,6 +23,7 @@
 pub mod hub;
 pub mod registry;
 pub mod security;
+pub mod skill_hub;
 pub mod toolsets;
 
 pub use registry::ToolRegistry;

--- a/crates/garudust-tools/src/skill_hub.rs
+++ b/crates/garudust-tools/src/skill_hub.rs
@@ -1,8 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
+use serde::Deserialize;
 
 const RAW_BASE: &str = "https://raw.githubusercontent.com";
+const GITHUB_API: &str = "https://api.github.com";
 
 // ── Source resolution ─────────────────────────────────────────────────────────
 
@@ -73,9 +75,92 @@ async fn fetch_text(url: &str) -> Result<String> {
         .context("read response body")
 }
 
+// ── GitHub scripts/ download ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct GitHubEntry {
+    name: String,
+    #[serde(rename = "type")]
+    kind: String,
+    download_url: Option<String>,
+}
+
+/// Fetch the `scripts/` directory from a GitHub skill path and write files to
+/// `dest_dir/scripts/`. Returns the number of files downloaded. Silently
+/// returns 0 if the directory does not exist (404) — not all skills have one.
+async fn download_scripts_github(
+    owner: &str,
+    repo: &str,
+    path: &str,
+    dest_dir: &Path,
+) -> Result<usize> {
+    let api_url = format!("{GITHUB_API}/repos/{owner}/{repo}/contents/{path}/scripts");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&api_url)
+        .header("User-Agent", "garudust")
+        .send()
+        .await
+        .with_context(|| format!("fetch {api_url}"))?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(0);
+    }
+
+    let entries: Vec<GitHubEntry> = resp
+        .error_for_status()
+        .with_context(|| format!("HTTP error listing scripts at {api_url}"))?
+        .json()
+        .await
+        .context("parse GitHub directory listing")?;
+
+    let scripts_dir = dest_dir.join("scripts");
+    tokio::fs::create_dir_all(&scripts_dir)
+        .await
+        .with_context(|| format!("create {}", scripts_dir.display()))?;
+
+    let mut count = 0usize;
+    for entry in entries {
+        if entry.kind != "file" {
+            continue;
+        }
+        let Some(dl_url) = entry.download_url else {
+            continue;
+        };
+        let content = fetch_text(&dl_url)
+            .await
+            .with_context(|| format!("download script {}", entry.name))?;
+        let file_path = scripts_dir.join(&entry.name);
+        tokio::fs::write(&file_path, content.as_bytes())
+            .await
+            .with_context(|| format!("write {}", file_path.display()))?;
+
+        #[cfg(unix)]
+        make_executable(&file_path).await?;
+
+        count += 1;
+    }
+
+    Ok(count)
+}
+
+#[cfg(unix)]
+async fn make_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let meta = tokio::fs::metadata(path).await?;
+    let mut perms = meta.permissions();
+    perms.set_mode(perms.mode() | 0o111);
+    tokio::fs::set_permissions(path, perms).await?;
+    Ok(())
+}
+
 // ── Install ───────────────────────────────────────────────────────────────────
 
 /// Download and install a skill into `skills_dir/<name>/SKILL.md`.
+///
+/// For GitHub sources the `scripts/` subdirectory is also downloaded (if present)
+/// so agentskills.io-compatible skills work out of the box.
 ///
 /// `source` accepts:
 /// - `owner/repo` or `owner/repo/path/to/skill` (GitHub)
@@ -86,10 +171,10 @@ async fn fetch_text(url: &str) -> Result<String> {
 pub async fn install_skill(source: &str, skill_name: &str, skills_dir: &Path) -> Result<String> {
     let resolved = resolve_source(source, skill_name)?;
 
-    let (content, name) = match &resolved {
+    // (content, name, github_coords_for_scripts)
+    let (content, name, gh) = match &resolved {
         SkillSource::Url(url) => {
             let text = fetch_text(url).await?;
-            // Derive name from URL filename if not given
             let name = if skill_name.is_empty() {
                 url.trim_end_matches('/')
                     .rsplit('/')
@@ -100,7 +185,7 @@ pub async fn install_skill(source: &str, skill_name: &str, skills_dir: &Path) ->
             } else {
                 skill_name.to_string()
             };
-            (text, name)
+            (text, name, None)
         }
 
         SkillSource::GitHub { owner, repo, path } => {
@@ -109,7 +194,8 @@ pub async fn install_skill(source: &str, skill_name: &str, skills_dir: &Path) ->
                 .await
                 .with_context(|| format!("skill not found at {url}"))?;
             let name = path.rsplit('/').next().unwrap_or(path).to_string();
-            (text, name)
+            let coords = (owner.clone(), repo.clone(), path.clone());
+            (text, name, Some(coords))
         }
 
         SkillSource::WellKnown { base, name } => {
@@ -117,7 +203,7 @@ pub async fn install_skill(source: &str, skill_name: &str, skills_dir: &Path) ->
             let text = fetch_text(&url)
                 .await
                 .with_context(|| format!("skill not found at {url}"))?;
-            (text, name.clone())
+            (text, name.clone(), None)
         }
     };
 
@@ -135,6 +221,11 @@ pub async fn install_skill(source: &str, skill_name: &str, skills_dir: &Path) ->
     tokio::fs::write(&skill_path, &content)
         .await
         .with_context(|| format!("write {}", skill_path.display()))?;
+
+    // Download scripts/ if this is a GitHub source
+    if let Some((owner, repo, path)) = gh {
+        download_scripts_github(&owner, &repo, &path, &dest_dir).await?;
+    }
 
     Ok(name)
 }

--- a/crates/garudust-tools/src/skill_hub.rs
+++ b/crates/garudust-tools/src/skill_hub.rs
@@ -1,0 +1,183 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+const RAW_BASE: &str = "https://raw.githubusercontent.com";
+
+// ── Source resolution ─────────────────────────────────────────────────────────
+
+/// Resolved download source for a skill.
+enum SkillSource {
+    /// Direct HTTPS URL to a SKILL.md file.
+    Url(String),
+    /// GitHub `owner/repo/path` — resolved to raw.githubusercontent.com.
+    GitHub {
+        owner: String,
+        repo: String,
+        path: String,
+    },
+    /// Well-known endpoint: fetch `{base}/.well-known/skills/{name}/SKILL.md`.
+    WellKnown { base: String, name: String },
+}
+
+/// Parse a user-supplied source string into a `SkillSource`.
+///
+/// Accepted forms:
+/// - `https://…/SKILL.md`               → direct URL
+/// - `well-known:https://example.com`   → well-known endpoint
+/// - `owner/repo/path/to/skill`         → GitHub (≥3 segments)
+fn resolve_source(source: &str, skill_name: &str) -> Result<SkillSource> {
+    if source.starts_with("well-known:") {
+        let base = source
+            .strip_prefix("well-known:")
+            .unwrap()
+            .trim_end_matches('/')
+            .to_string();
+        return Ok(SkillSource::WellKnown {
+            base,
+            name: skill_name.to_string(),
+        });
+    }
+
+    if source.starts_with("https://") || source.starts_with("http://") {
+        return Ok(SkillSource::Url(source.to_string()));
+    }
+
+    // GitHub: owner/repo or owner/repo/path/to/skill
+    let parts: Vec<&str> = source.splitn(3, '/').collect();
+    match parts.as_slice() {
+        [owner, repo] => Ok(SkillSource::GitHub {
+            owner: (*owner).to_string(),
+            repo: (*repo).to_string(),
+            path: skill_name.to_string(),
+        }),
+        [owner, repo, path] => Ok(SkillSource::GitHub {
+            owner: (*owner).to_string(),
+            repo: (*repo).to_string(),
+            path: (*path).to_string(),
+        }),
+        _ => bail!(
+            "cannot resolve source '{}'. Use: owner/repo/path, https://…/SKILL.md, or well-known:https://…",
+            source
+        ),
+    }
+}
+
+async fn fetch_text(url: &str) -> Result<String> {
+    reqwest::get(url)
+        .await
+        .with_context(|| format!("fetch {url}"))?
+        .error_for_status()
+        .with_context(|| format!("HTTP error fetching {url}"))?
+        .text()
+        .await
+        .context("read response body")
+}
+
+// ── Install ───────────────────────────────────────────────────────────────────
+
+/// Download and install a skill into `skills_dir/<name>/SKILL.md`.
+///
+/// `source` accepts:
+/// - `owner/repo` or `owner/repo/path/to/skill` (GitHub)
+/// - `https://example.com/SKILL.md` (direct URL)
+/// - `well-known:https://example.com` (well-known endpoint)
+///
+/// Returns the skill name as written to disk.
+pub async fn install_skill(source: &str, skill_name: &str, skills_dir: &Path) -> Result<String> {
+    let resolved = resolve_source(source, skill_name)?;
+
+    let (content, name) = match &resolved {
+        SkillSource::Url(url) => {
+            let text = fetch_text(url).await?;
+            // Derive name from URL filename if not given
+            let name = if skill_name.is_empty() {
+                url.trim_end_matches('/')
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(skill_name)
+                    .trim_end_matches(".md")
+                    .to_string()
+            } else {
+                skill_name.to_string()
+            };
+            (text, name)
+        }
+
+        SkillSource::GitHub { owner, repo, path } => {
+            let url = format!("{RAW_BASE}/{owner}/{repo}/main/{path}/SKILL.md");
+            let text = fetch_text(&url)
+                .await
+                .with_context(|| format!("skill not found at {url}"))?;
+            let name = path.rsplit('/').next().unwrap_or(path).to_string();
+            (text, name)
+        }
+
+        SkillSource::WellKnown { base, name } => {
+            let url = format!("{base}/.well-known/skills/{name}/SKILL.md");
+            let text = fetch_text(&url)
+                .await
+                .with_context(|| format!("skill not found at {url}"))?;
+            (text, name.clone())
+        }
+    };
+
+    // Validate it looks like a SKILL.md
+    if !content.trim_start().starts_with("---") {
+        bail!("downloaded content does not look like a valid SKILL.md (missing frontmatter)");
+    }
+
+    let skill_dir = skills_dir.join(&name);
+    tokio::fs::create_dir_all(&skill_dir)
+        .await
+        .with_context(|| format!("create {}", skill_dir.display()))?;
+
+    let skill_path = skill_dir.join("SKILL.md");
+    tokio::fs::write(&skill_path, &content)
+        .await
+        .with_context(|| format!("write {}", skill_path.display()))?;
+
+    Ok(name)
+}
+
+// ── List ──────────────────────────────────────────────────────────────────────
+
+pub struct InstalledSkill {
+    pub name: String,
+    pub description: String,
+    pub version: String,
+}
+
+/// List skills installed in `skills_dir` by scanning for SKILL.md files.
+pub async fn list_installed(skills_dir: &Path) -> Vec<InstalledSkill> {
+    let skills = crate::toolsets::skills::load_skills_from_dir(skills_dir).await;
+    skills
+        .into_iter()
+        .map(|s| InstalledSkill {
+            name: s.name,
+            description: s.description,
+            version: s.version.unwrap_or_else(|| "—".into()),
+        })
+        .collect()
+}
+
+// ── Uninstall ─────────────────────────────────────────────────────────────────
+
+/// Remove a skill folder from `skills_dir`.
+pub async fn uninstall_skill(skill_name: &str, skills_dir: &Path) -> Result<()> {
+    let skill_dir = find_skill_dir(skills_dir, skill_name).await?;
+    tokio::fs::remove_dir_all(&skill_dir)
+        .await
+        .with_context(|| format!("remove {}", skill_dir.display()))
+}
+
+/// Walk `skills_dir` recursively to find the folder whose SKILL.md has `name: <skill_name>`.
+async fn find_skill_dir(skills_dir: &Path, skill_name: &str) -> Result<PathBuf> {
+    let skills = crate::toolsets::skills::load_skills_from_dir(skills_dir).await;
+    let skill = skills
+        .into_iter()
+        .find(|s| s.name == skill_name)
+        .with_context(|| format!("skill '{skill_name}' is not installed"))?;
+
+    Ok(skill.path.parent().unwrap_or(&skill.path).to_path_buf())
+}

--- a/crates/garudust-tools/src/skill_hub.rs
+++ b/crates/garudust-tools/src/skill_hub.rs
@@ -57,8 +57,7 @@ fn resolve_source(source: &str, skill_name: &str) -> Result<SkillSource> {
             path: (*path).to_string(),
         }),
         _ => bail!(
-            "cannot resolve source '{}'. Use: owner/repo/path, https://…/SKILL.md, or well-known:https://…",
-            source
+            "cannot resolve source '{source}'. Use: owner/repo/path, https://…/SKILL.md, or well-known:https://…"
         ),
     }
 }
@@ -127,12 +126,12 @@ pub async fn install_skill(source: &str, skill_name: &str, skills_dir: &Path) ->
         bail!("downloaded content does not look like a valid SKILL.md (missing frontmatter)");
     }
 
-    let skill_dir = skills_dir.join(&name);
-    tokio::fs::create_dir_all(&skill_dir)
+    let dest_dir = skills_dir.join(&name);
+    tokio::fs::create_dir_all(&dest_dir)
         .await
-        .with_context(|| format!("create {}", skill_dir.display()))?;
+        .with_context(|| format!("create {}", dest_dir.display()))?;
 
-    let skill_path = skill_dir.join("SKILL.md");
+    let skill_path = dest_dir.join("SKILL.md");
     tokio::fs::write(&skill_path, &content)
         .await
         .with_context(|| format!("write {}", skill_path.display()))?;
@@ -165,10 +164,10 @@ pub async fn list_installed(skills_dir: &Path) -> Vec<InstalledSkill> {
 
 /// Remove a skill folder from `skills_dir`.
 pub async fn uninstall_skill(skill_name: &str, skills_dir: &Path) -> Result<()> {
-    let skill_dir = find_skill_dir(skills_dir, skill_name).await?;
-    tokio::fs::remove_dir_all(&skill_dir)
+    let target_dir = find_skill_dir(skills_dir, skill_name).await?;
+    tokio::fs::remove_dir_all(&target_dir)
         .await
-        .with_context(|| format!("remove {}", skill_dir.display()))
+        .with_context(|| format!("remove {}", target_dir.display()))
 }
 
 /// Walk `skills_dir` recursively to find the folder whose SKILL.md has `name: <skill_name>`.

--- a/crates/garudust-tools/src/toolsets/skills.rs
+++ b/crates/garudust-tools/src/toolsets/skills.rs
@@ -257,8 +257,8 @@ impl Tool for SkillView {
             ctx.skill_permissions.write().await.merge(perms);
         }
 
-        let skill_dir = skill.path.parent().unwrap_or(&skill.path);
-        let scripts_dir = skill_dir.join("scripts");
+        let install_dir = skill.path.parent().unwrap_or(&skill.path);
+        let scripts_dir = install_dir.join("scripts");
         let scripts_note = if scripts_dir.exists() {
             format!("\n\n**Scripts directory:** `{}`", scripts_dir.display())
         } else {

--- a/crates/garudust-tools/src/toolsets/skills.rs
+++ b/crates/garudust-tools/src/toolsets/skills.rs
@@ -257,9 +257,17 @@ impl Tool for SkillView {
             ctx.skill_permissions.write().await.merge(perms);
         }
 
+        let skill_dir = skill.path.parent().unwrap_or(&skill.path);
+        let scripts_dir = skill_dir.join("scripts");
+        let scripts_note = if scripts_dir.exists() {
+            format!("\n\n**Scripts directory:** `{}`", scripts_dir.display())
+        } else {
+            String::new()
+        };
+
         Ok(ToolResult::ok(
             "",
-            format!("# {}\n\n{}", skill.name, skill.body),
+            format!("# {}{}\n\n{}", skill.name, scripts_note, skill.body),
         ))
     }
 }


### PR DESCRIPTION
## Summary

- Add `garudust skill install <source>` supporting 3 source formats:
  - `owner/repo/path` — GitHub (raw.githubusercontent.com)
  - `https://…/SKILL.md` — direct URL
  - `well-known:https://…` — `/.well-known/skills/<name>/SKILL.md`
- Add `garudust skill list` — scans `~/.garudust/skills/` and shows name, version, description
- Add `garudust skill uninstall <name>` — removes skill folder by name
- New `crates/garudust-tools/src/skill_hub.rs` handles all download/resolve logic
- New `bin/garudust/src/skill_cmd.rs` handles CLI output formatting

## Test plan

- [x] `garudust skill --help` — subcommands listed correctly
- [x] `garudust skill list` — shows installed skills from `~/.garudust/skills/`
- [x] `cargo clippy` (pedantic) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace` — all pass

## Usage

```bash
garudust skill install openai/skills/git-ops
garudust skill install https://example.com/SKILL.md
garudust skill install well-known:https://mintlify.com/docs --name mintlify
garudust skill list
garudust skill uninstall git-ops
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)