### PR TITLE
fix(transport,cli): handle zero-arg tool calls, fix TUI scroll & skill hub install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ tera = "1"
 
 # CLI / TUI
 clap      = { version = "4", features = ["derive", "env"] }
-ratatui   = "0.30"
+ratatui   = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = "0.28"
 
 # Cron

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -68,18 +68,22 @@ enum ToolCmd {
 enum SkillCmd {
     /// List installed skills
     List,
-    /// Install a skill from GitHub, a direct URL, or a well-known endpoint
+    /// Install a skill from the hub, GitHub, a direct URL, or a well-known endpoint
     ///
     /// Sources:
+    ///   git-workflow         — short name (resolved via hub index)
     ///   owner/repo/path      — GitHub (raw.githubusercontent.com)
     ///   https://…/SKILL.md   — direct URL
     ///   well-known:https://… — /.well-known/skills/<name>/SKILL.md
     Install {
-        /// Source (GitHub path, URL, or well-known prefix)
+        /// Skill name (short) or full source path / URL
         source: String,
         /// Skill name to use when saving (inferred from source if omitted)
         #[arg(long, default_value = "")]
         name: String,
+        /// Hub repository (default: garudust-org/garudust-hub)
+        #[arg(long, default_value = garudust_tools::hub::DEFAULT_HUB)]
+        hub: String,
     },
     /// Remove an installed skill
     Uninstall {
@@ -297,8 +301,8 @@ async fn main() -> Result<()> {
                 SkillCmd::List => {
                     skill_cmd::list(&skills_dir).await?;
                 }
-                SkillCmd::Install { source, name } => {
-                    skill_cmd::install(source, name, &skills_dir).await?;
+                SkillCmd::Install { source, name, hub } => {
+                    skill_cmd::install(source, name, hub, &skills_dir).await?;
                 }
                 SkillCmd::Uninstall { name } => {
                     skill_cmd::uninstall(name, &skills_dir).await?;

--- a/bin/garudust/src/skill_cmd.rs
+++ b/bin/garudust/src/skill_cmd.rs
@@ -37,10 +37,21 @@ pub async fn list(skills_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-pub async fn install(source: &str, name: &str, skills_dir: &Path) -> Result<()> {
-    println!("Installing skill from '{source}'...");
-    let installed_name = skill_hub::install_skill(source, name, skills_dir).await?;
-    println!("Installed skill '{installed_name}'.");
+pub async fn install(source: &str, name: &str, hub: &str, skills_dir: &Path) -> Result<()> {
+    let is_short_name = !source.contains('/')
+        && !source.starts_with("https://")
+        && !source.starts_with("http://")
+        && !source.starts_with("well-known:");
+
+    if is_short_name {
+        println!("Installing skill '{source}' from hub {hub}...");
+        garudust_tools::hub::install_skill_from_hub(hub, source, skills_dir).await?;
+        println!("Installed skill '{source}'.");
+    } else {
+        println!("Installing skill from '{source}'...");
+        let installed_name = skill_hub::install_skill(source, name, skills_dir).await?;
+        println!("Installed skill '{installed_name}'.");
+    }
     Ok(())
 }
 

--- a/bin/garudust/src/tui.rs
+++ b/bin/garudust/src/tui.rs
@@ -44,6 +44,7 @@ pub struct Tui {
     status: String,
     scroll: u16,
     streaming: bool,
+    thinking_since: Option<std::time::Instant>,
     toolsets: BTreeMap<String, Vec<String>>,
     skill_names: Vec<String>,
 }
@@ -63,6 +64,7 @@ impl Tui {
             status: "Ready — press Enter to send, Ctrl+C to quit".into(),
             scroll: 0,
             streaming: false,
+            thinking_since: None,
             toolsets,
             skill_names,
         }
@@ -189,12 +191,14 @@ impl Tui {
                     }
                 } else {
                     self.streaming = true;
+                    self.status = "Streaming…".into();
                     self.messages.push((Role::Assistant, delta));
                 }
                 self.scroll = u16::MAX;
             }
             AgentEvent::Thinking => {
                 self.streaming = false;
+                self.thinking_since = Some(std::time::Instant::now());
                 self.status = "Thinking…".into();
             }
             AgentEvent::Done {
@@ -203,14 +207,17 @@ impl Tui {
                 output_tokens,
             } => {
                 self.streaming = false;
+                self.thinking_since = None;
                 self.status = format!(
                     "Done — {iterations} iter | {input_tokens} in / {output_tokens} out tokens"
                 );
             }
             AgentEvent::Error(e) => {
                 self.streaming = false;
+                self.thinking_since = None;
                 self.messages.push((Role::Error, format!("Error: {e}")));
                 self.status = "Error — ready for next task".into();
+                self.scroll = u16::MAX;
             }
         }
     }
@@ -370,23 +377,43 @@ impl Tui {
 
         let all_lines: Vec<Line<'static>> = banner.into_iter().chain(chat_lines).collect();
 
-        let total_lines = u16::try_from(all_lines.len()).unwrap_or(u16::MAX);
         let visible = chunks[0].height.saturating_sub(2);
-        let scroll = if self.scroll == u16::MAX {
-            total_lines.saturating_sub(visible)
-        } else {
-            self.scroll.min(total_lines.saturating_sub(visible))
-        };
 
+        // Build Paragraph first so we can query its wrapped line count.
+        // With Wrap enabled, ratatui's scroll is in visual rows (after wrapping),
+        // not logical lines.  line_count() gives the correct total visual rows.
         let messages = Paragraph::new(Text::from(all_lines))
             .block(Block::default().borders(Borders::ALL).title(" Garudust "))
-            .wrap(Wrap { trim: false })
-            .scroll((scroll, 0));
+            .wrap(Wrap { trim: false });
+
+        let text_w = chunks[0].width.saturating_sub(2);
+        // line_count(text_w) returns wrapped_rows + top_border + bottom_border (= +2 for Borders::ALL).
+        // visible already excludes the 2 border rows (chunks[0].height - 2).
+        // So the scrollable content rows = total_visual - 2; max_scroll = content_rows - visible.
+        let total_visual = u16::try_from(messages.line_count(text_w)).unwrap_or(u16::MAX);
+        let max_scroll = total_visual.saturating_sub(visible + 2);
+        let scroll = if self.scroll == u16::MAX {
+            max_scroll
+        } else {
+            self.scroll.min(max_scroll)
+        };
+
+        let messages = messages.scroll((scroll, 0));
         f.render_widget(messages, chunks[0]);
 
         // ── Status bar ──
+        let status_text = if let Some(since) = self.thinking_since {
+            let secs = since.elapsed().as_secs();
+            if secs > 0 {
+                format!("{} ({}s)", self.status, secs)
+            } else {
+                self.status.clone()
+            }
+        } else {
+            self.status.clone()
+        };
         let status =
-            Paragraph::new(self.status.as_str()).style(Style::default().fg(Color::DarkGray));
+            Paragraph::new(status_text.as_str()).style(Style::default().fg(Color::DarkGray));
         f.render_widget(status, chunks[1]);
 
         // ── Input box ──

--- a/crates/garudust-tools/src/hub.rs
+++ b/crates/garudust-tools/src/hub.rs
@@ -151,11 +151,7 @@ pub async fn install_tool(repo: &str, tool_name: &str, tools_dir: &Path) -> Resu
 
 /// Download a skill from the hub into `skills_dir/<skill_name>/`.
 /// Files listed in the index entry are fetched from `skills/<name>/` in the hub repo.
-pub async fn install_skill_from_hub(
-    repo: &str,
-    skill_name: &str,
-    skills_dir: &Path,
-) -> Result<()> {
+pub async fn install_skill_from_hub(repo: &str, skill_name: &str, skills_dir: &Path) -> Result<()> {
     let index = fetch_index(repo).await?;
     let entry = index
         .skills

--- a/crates/garudust-tools/src/hub.rs
+++ b/crates/garudust-tools/src/hub.rs
@@ -17,6 +17,16 @@ fn raw_url(repo: &str, branch: &str, path: &str) -> String {
 pub struct HubIndex {
     #[serde(default)]
     pub tools: Vec<HubToolEntry>,
+    #[serde(default)]
+    pub skills: Vec<HubSkillEntry>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct HubSkillEntry {
+    pub name: String,
+    pub description: String,
+    pub version: String,
+    pub files: Vec<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -135,6 +145,67 @@ pub async fn install_tool(repo: &str, tool_name: &str, tools_dir: &Path) -> Resu
     write_registry(tools_dir, &registry).await?;
 
     Ok(entry.requires())
+}
+
+// ── Install skill from hub ────────────────────────────────────────────────────
+
+/// Download a skill from the hub into `skills_dir/<skill_name>/`.
+/// Files listed in the index entry are fetched from `skills/<name>/` in the hub repo.
+pub async fn install_skill_from_hub(
+    repo: &str,
+    skill_name: &str,
+    skills_dir: &Path,
+) -> Result<()> {
+    let index = fetch_index(repo).await?;
+    let entry = index
+        .skills
+        .iter()
+        .find(|s| s.name == skill_name)
+        .with_context(|| format!("skill '{skill_name}' not found in hub {repo}"))?
+        .clone();
+
+    let install_dir = skills_dir.join(&entry.name);
+    tokio::fs::create_dir_all(&install_dir)
+        .await
+        .with_context(|| format!("create {}", install_dir.display()))?;
+
+    let client = reqwest::Client::new();
+    for file in &entry.files {
+        let hub_path = format!("skills/{}/{file}", entry.name);
+        let url = raw_url(repo, "main", &hub_path);
+        let bytes = client
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("fetch {url}"))?
+            .error_for_status()
+            .with_context(|| format!("file not found: {url}"))?
+            .bytes()
+            .await?;
+
+        let dest = install_dir.join(file);
+        if let Some(parent) = dest.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&dest, &bytes)
+            .await
+            .with_context(|| format!("write {}", dest.display()))?;
+
+        #[cfg(unix)]
+        {
+            let ext = std::path::Path::new(file.as_str())
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if ext.eq_ignore_ascii_case("sh") || ext.eq_ignore_ascii_case("py") {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = std::fs::Permissions::from_mode(0o755);
+                tokio::fs::set_permissions(&dest, perms).await?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 // ── Uninstall ─────────────────────────────────────────────────────────────────

--- a/crates/garudust-transport/src/chat_completions.rs
+++ b/crates/garudust-transport/src/chat_completions.rs
@@ -274,7 +274,7 @@ impl ProviderTransport for ChatCompletionsTransport {
             // tool call accumulator: index → (id, name, args)
             let mut tc_acc: Vec<(String, String, String)> = Vec::new();
 
-            while let Some(chunk) = byte_stream.next().await {
+            'outer: while let Some(chunk) = byte_stream.next().await {
                 let bytes = chunk.map_err(|e| TransportError::Stream(e.to_string()))?;
                 buf.push_str(&String::from_utf8_lossy(&bytes));
 
@@ -287,7 +287,7 @@ impl ProviderTransport for ChatCompletionsTransport {
                     };
                     let data = d.to_string();
                     if data == "[DONE]" {
-                        break;
+                        break 'outer;  // exit both loops; don't wait for server to close connection
                     }
 
                     let Ok(event) = serde_json::from_str::<Value>(&data) else {
@@ -358,6 +358,23 @@ impl ProviderTransport for ChatCompletionsTransport {
                                         None
                                     },
                                     args_delta: args.to_string(),
+                                };
+                            }
+                        }
+                    }
+
+                    // Some providers (e.g. vLLM with zero-arg tools) send finish_reason
+                    // "tool_calls" in the same chunk as the tool call delta but never send
+                    // an "arguments" field. Emit a ToolCallDelta here so stream_turn sees
+                    // the call; use "{}" as the argument payload.
+                    if choice["finish_reason"].as_str() == Some("tool_calls") {
+                        for (idx, (acc_id, acc_name, acc_args)) in tc_acc.iter().enumerate() {
+                            if !acc_id.is_empty() && acc_args.is_empty() {
+                                yield StreamChunk::ToolCallDelta {
+                                    index: idx,
+                                    id: Some(acc_id.clone()),
+                                    name: Some(acc_name.clone()),
+                                    args_delta: "{}".to_string(),
                                 };
                             }
                         }


### PR DESCRIPTION
## Summary

- **fix(transport):** vLLM never sends an `arguments` field for zero-argument tools (e.g. `skills_list`). The streaming parser only yielded `ToolCallDelta` inside `if let Some(args) = ...`, so `stream_turn` never saw the tool call → agent returned after 1 iteration with empty content and the TUI showed nothing. Fix: when `finish_reason: "tool_calls"` arrives and the accumulator has entries with id+name but no args, emit `ToolCallDelta { args_delta: "{}" }`.
- **fix(transport):** `break` → `break 'outer` so the SSE reader exits both loops on `[DONE]` instead of waiting for the server to close the connection.
- **fix(cli/tui):** Scroll formula used raw logical line count; with `Wrap` enabled, ratatui's `line_count(width)` gives visual rows after wrapping. Enable `unstable-rendered-line-info` ratatui feature and use corrected `max_scroll = total_visual - (visible + 2)`.
- **fix(cli/tui):** Add `thinking_since` timer so the status bar shows elapsed seconds while the model is working.
- **fix(cli/tui):** Set status to "Streaming…" when the first chunk arrives; auto-scroll to bottom on error.
- **feat(tools,cli):** Add `install_skill_from_hub()` and `HubSkillEntry` to hub index. Extend `garudust skill install` with `--hub` flag; short names (no `/` or `://`) are resolved via the hub index.

## Test plan

- [ ] Start TUI, send a message that triggers a zero-arg tool call (e.g. "คุณทำอะไรได้บ้าง" with `skills_list` in tool set) — AI should respond instead of showing "Done — 1 iter | 16 out tokens" with no text
- [ ] Verify scroll auto-follows new output and `↑`/`↓` keys work correctly with wrapped lines
- [ ] Status bar shows `"Thinking… (Xs)"` elapsed timer during model inference
- [ ] `garudust skill install <short-name>` resolves from hub index
- [ ] `cargo test --workspace` passes (282 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)