### PR TITLE
fix: view_image uv PATH + config watcher reload loop

### DIFF
--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -18,7 +18,8 @@ use garudust_tools::{
     toolsets::mcp::connect_mcp_server, ToolRegistry,
 };
 use garudust_transport::build_transport;
-use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use notify::event::ModifyKind;
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 // Each element is held only for its Drop impl — dropping terminates the MCP child process.
 type McpHandles = Vec<Box<dyn std::any::Any + Send>>;
@@ -271,11 +272,24 @@ fn spawn_config_watcher(
         let mut watcher: RecommendedWatcher =
             match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
                 if let Ok(event) = res {
+                    // Only react to genuine content changes. Reloading reads
+                    // config.yaml via AgentConfig::load(), which emits inotify
+                    // Access (open/read/close) events on the watched file — if
+                    // those triggered a reload we would loop forever. Accept
+                    // create/remove/rename/data-modify; drop Access & Metadata.
+                    let is_content_change = matches!(
+                        event.kind,
+                        EventKind::Create(_)
+                            | EventKind::Remove(_)
+                            | EventKind::Modify(ModifyKind::Data(_))
+                            | EventKind::Modify(ModifyKind::Name(_))
+                            | EventKind::Modify(ModifyKind::Any)
+                    );
                     let matches = event
                         .paths
                         .iter()
                         .any(|p| p.file_name() == Some(filename.as_os_str()));
-                    if matches {
+                    if is_content_change && matches {
                         let _ = tx2.send(());
                     }
                 }

--- a/crates/garudust-tools/src/toolsets/script.rs
+++ b/crates/garudust-tools/src/toolsets/script.rs
@@ -140,12 +140,33 @@ impl Tool for ScriptTool {
 
         let dotenv_vars = read_dotenv(&ctx.config.home_dir.join(".env"));
 
+        // `uv` (and other user-installed runtimes) typically live in
+        // ~/.local/bin, which is NOT in the server's PATH when launched as a
+        // daemon (PPID 1 / desktop entry / systemd unit strip it). Without this,
+        // tools that shell out to `uv` fail with `sh: uv: not found` (exit 127).
+        // Mirrors the augmentation in garudust-gateway's process_images path so
+        // both the gateway and agent-driven tool calls behave identically.
+        let augmented_path = {
+            let cur = std::env::var("PATH").unwrap_or_default();
+            match std::env::var("HOME") {
+                Ok(home) if !home.is_empty() => {
+                    let extra = format!("{home}/.local/bin");
+                    if cur.split(':').any(|seg| seg == extra) {
+                        cur
+                    } else {
+                        format!("{extra}:{cur}")
+                    }
+                }
+                _ => cur,
+            }
+        };
+
         let mut cmd = Command::new("sh");
         cmd.arg("-c")
             .arg(&command)
             .current_dir(&self.tool_dir)
             .env_clear()
-            .env("PATH", std::env::var("PATH").unwrap_or_default())
+            .env("PATH", &augmented_path)
             .env("HOME", std::env::var("HOME").unwrap_or_default())
             .env("LANG", "en_US.UTF-8")
             .env("TOOL_DIR", &self.tool_dir);


### PR DESCRIPTION
## Summary

Fixes two independent bugs that combined to make the LINE image bot intermittently fail ("sometimes answers images, sometimes apologizes"):

1. **`uv: not found` (exit 127)** — The script toolset spawned `sh -c` with the server's raw PATH. When the server runs as a daemon (PPID 1 / systemd / desktop entry), PATH is stripped to `/usr/local/bin:/usr/bin:/bin`, so tools shelling out to `uv` (e.g. `view_image`) failed whenever the agent invoked the tool directly. The gateway's `process_images` path already augmented PATH; this mirrors it in the script toolset so both paths behave identically.

2. **Config watcher reload loop (~3/s)** — The hot-reload watcher matched events purely by filename. Reloading calls `AgentConfig::load()`, which opens/reads `config.yaml`, emitting inotify **Access** (open/read/close) events on the watched file. Those re-triggered the reload → infinite loop constantly rebuilding the agent + tool registry mid-request. Now filtered to genuine content changes (`Create`/`Remove`/`Modify-Data`/`Modify-Name`); `Access` and `Metadata` ignored.

## Commits
- `fix(tools)`: augment PATH with `~/.local/bin` for script tool subprocesses
- `fix(server)`: only reload config on content-change events, not Access

## Testing
- `view_image` now resolves `uv` and runs end-to-end when the agent calls it directly.
- `config changed` reload count = **0 over 6+ minutes** after the watcher fix (previously ~3/s indefinitely).
- Verified live against the running LINE deployment.

## Out of scope (runtime files, not in repo)
The `~/.garudust/tools/view_image/run.py` + `tool.yaml` changes (switch to Gemini `gemini-flash-latest`, retry-on-429 + OpenRouter fallback) live outside the repo and are already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)