### PR TITLE
fix(clippy): nest Modify or-patterns in config watcher

### DIFF
--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -282,9 +282,7 @@ fn spawn_config_watcher(
                         EventKind::Create(_)
                             | EventKind::Remove(_)
                             | EventKind::Modify(
-                                ModifyKind::Data(_)
-                                    | ModifyKind::Name(_)
-                                    | ModifyKind::Any
+                                ModifyKind::Data(_) | ModifyKind::Name(_) | ModifyKind::Any
                             )
                     );
                     let matches = event

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -281,9 +281,11 @@ fn spawn_config_watcher(
                         event.kind,
                         EventKind::Create(_)
                             | EventKind::Remove(_)
-                            | EventKind::Modify(ModifyKind::Data(_))
-                            | EventKind::Modify(ModifyKind::Name(_))
-                            | EventKind::Modify(ModifyKind::Any)
+                            | EventKind::Modify(
+                                ModifyKind::Data(_)
+                                    | ModifyKind::Name(_)
+                                    | ModifyKind::Any
+                            )
                     );
                     let matches = event
                         .paths


### PR DESCRIPTION
## Summary

The `Check & Clippy` job failed on `main` after #118 merged: `clippy::unnested_or_patterns` (pedantic, `-D warnings`) at `bin/garudust-server/src/main.rs:282`.

The watcher `matches!` had three separate `EventKind::Modify(...)` arms; collapsed into a single `EventKind::Modify(ModifyKind::Data(_) | ModifyKind::Name(_) | ModifyKind::Any)`. Behaviour is identical.

Verified locally with the exact CI clippy flags (`-W clippy::pedantic -D warnings` + the configured allows) — passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)