### PR TITLE
fix(doctor,config): resolve providers.default profile for diagnostics

### DIFF
--- a/bin/garudust/src/config_cmd.rs
+++ b/bin/garudust/src/config_cmd.rs
@@ -140,8 +140,10 @@ pub fn show(config: &AgentConfig) {
     println!("model           : {}", config.model);
     println!("max_iterations  : {}", config.max_iterations);
     println!("tool_delay_ms   : {}", config.tool_delay_ms);
-    let effective_url = config
-        .base_url
+    // Honour `providers.default` (its `url:` or built-in default for `name:`)
+    // before the legacy `base_url:` field.
+    let effective_url_owned = config.effective_base_url();
+    let effective_url = effective_url_owned
         .as_deref()
         .unwrap_or(match config.provider.as_str() {
             "anthropic" => "https://api.anthropic.com/v1/messages (native)",
@@ -154,14 +156,23 @@ pub fn show(config: &AgentConfig) {
         });
     println!("base_url        : {effective_url}");
     println!("approval_mode   : {}", config.security.approval_mode);
-    let source_env = match config.provider.as_str() {
+    // Prefer the `${ENV_VAR}` named in the default profile's `key:`; otherwise
+    // fall back to the conventional per-provider env var.
+    let profile_env = config
+        .providers
+        .get("default")
+        .and_then(|p| p.key.as_deref())
+        .and_then(|k| k.strip_prefix("${").and_then(|s| s.strip_suffix('}')))
+        .map(str::to_string);
+    let source_env = profile_env.as_deref().or(match config.provider.as_str() {
         "vllm" => Some("VLLM_API_KEY"),
         "anthropic" => Some("ANTHROPIC_API_KEY"),
         "thaillm" => Some("THAILLM_API_KEY"),
         "openrouter" => Some("OPENROUTER_API_KEY"),
         _ => None,
-    };
-    let key_display = match (&config.api_key, source_env) {
+    });
+    let api_key = config.effective_api_key();
+    let key_display = match (&api_key, source_env) {
         (Some(k), Some(env)) if k.len() > 10 => {
             format!("{}…{} (from {env})", &k[..6], &k[k.len() - 4..])
         }

--- a/bin/garudust/src/doctor.rs
+++ b/bin/garudust/src/doctor.rs
@@ -60,26 +60,27 @@ pub async fn run(config: &AgentConfig) {
     checks.push(Check::ok("Model", &config.model));
 
     // ── API Key ──────────────────────────────────────────────────────────────
+    let api_key = config.effective_api_key();
     match config.provider.as_str() {
         "ollama" => {
             checks.push(Check::ok("API key", "not required (ollama)"));
         }
         "vllm" => {
-            if let Some(k) = &config.api_key {
+            if let Some(k) = &api_key {
                 checks.push(Check::ok("API key", redact(k)));
             } else {
                 checks.push(Check::ok("API key", "not required (vllm)"));
             }
         }
         "anthropic" => {
-            if let Some(k) = &config.api_key {
+            if let Some(k) = &api_key {
                 checks.push(Check::ok("API key", redact(k)));
             } else {
                 checks.push(Check::fail("API key", "not set — export ANTHROPIC_API_KEY"));
             }
         }
         _ => {
-            if let Some(k) = &config.api_key {
+            if let Some(k) = &api_key {
                 checks.push(Check::ok("API key", redact(k)));
             } else {
                 checks.push(Check::fail(
@@ -91,9 +92,10 @@ pub async fn run(config: &AgentConfig) {
     }
 
     // ── Connectivity ─────────────────────────────────────────────────────────
+    // Honour `providers.default` (its `url:` or built-in default for `name:`)
+    // before the legacy `base_url:`; only then fall back to provider defaults.
     let base = config
-        .base_url
-        .clone()
+        .effective_base_url()
         .unwrap_or_else(|| match config.provider.as_str() {
             "anthropic" => "https://api.anthropic.com".into(),
             "ollama" => "http://localhost:11434".into(),

--- a/crates/garudust-core/src/config.rs
+++ b/crates/garudust-core/src/config.rs
@@ -234,6 +234,21 @@ impl ProviderProfile {
             Some(k.to_string())
         }
     }
+
+    /// Effective base URL for this profile: an explicit `url:`, otherwise the
+    /// built-in default for `name:`. Returns `None` for special transports
+    /// (anthropic / ollama / bedrock) that have no entry in `BUILTIN_PROVIDERS`
+    /// and for profiles with neither a `url` nor a recognised `name`.
+    pub fn resolved_base_url(&self) -> Option<String> {
+        if let Some(url) = &self.url {
+            return Some(url.clone());
+        }
+        let name = self.name.as_deref()?;
+        BUILTIN_PROVIDERS
+            .iter()
+            .find(|p| p.name == name)
+            .map(|p| p.base_url.to_string())
+    }
 }
 
 /// Per-tool or per-skill configuration overrides.
@@ -864,6 +879,31 @@ pub(crate) fn detect_provider_from_env(config: &mut AgentConfig, dotenv: &HashMa
 }
 
 impl AgentConfig {
+    /// Effective transport base URL, honouring the new `providers.default`
+    /// profile first (its `url:` or the built-in default for its `name:`),
+    /// then falling back to the legacy top-level `base_url:` field.
+    /// `None` means "use the provider's built-in default" — callers that need
+    /// a concrete URL (doctor, `config show`) supply their own provider match.
+    pub fn effective_base_url(&self) -> Option<String> {
+        if let Some(p) = self.providers.get("default") {
+            if let Some(url) = p.resolved_base_url() {
+                return Some(url);
+            }
+        }
+        self.base_url.clone()
+    }
+
+    /// Effective API key, honouring the `providers.default` profile's resolved
+    /// `key:` first, then the legacy `api_key` field populated by `load()`.
+    pub fn effective_api_key(&self) -> Option<String> {
+        if let Some(p) = self.providers.get("default") {
+            if let Some(k) = p.resolved_key() {
+                return Some(k);
+            }
+        }
+        self.api_key.clone()
+    }
+
     /// Canonical ~/.garudust directory.
     pub fn garudust_dir() -> PathBuf {
         dirs::home_dir()


### PR DESCRIPTION
## Problem

`garudust doctor` and `garudust config show` read only the legacy
`config.base_url` / `config.api_key` fields. Under the new
`providers.default` profile system these fields are unset, so the tools
fell back to built-in provider defaults and reported the **wrong
endpoint** — e.g. vllm `localhost:8000` instead of the profile's
`localhost:12345` — producing a misleading `Connectivity: unreachable`
failure even though the agent transport was correctly configured.

## Fix

- `ProviderProfile::resolved_base_url()` — explicit `url:`, else the
  built-in default for `name:`.
- `AgentConfig::effective_base_url()` / `effective_api_key()` — consult
  `providers.default` first, then fall back to the legacy fields.
- Wire `doctor.rs` and `config_cmd.rs` through these helpers; the
  `(from ENV)` label now derives the env var from the profile's
  `${VAR}` key reference.

## Verification

| | before | after |
|---|---|---|
| doctor connectivity | `localhost:8000 — unreachable` ✗ | `localhost:12345 (1ms)` ✓ |
| `config show` base_url | `http://localhost:8000/v1` (wrong) | `http://localhost:12345/v1` |
| doctor summary | `1 check(s) failed` | All checks passed |

`cargo test --workspace` — no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)