### PR TITLE
chore(deps): prune unused workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,16 +1676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
-dependencies = [
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,11 +1823,8 @@ dependencies = [
  "garudust-memory",
  "garudust-tools",
  "garudust-transport",
- "serde",
  "serde_json",
- "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1857,7 +1844,6 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -1868,13 +1854,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "chrono-tz",
- "fs4",
  "garudust-agent",
  "garudust-core",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
  "tokio",
  "tokio-cron-scheduler",
  "tracing",
@@ -1902,11 +1883,9 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
- "tower-http",
  "tower_governor",
  "tracing",
  "uuid",
@@ -1918,15 +1897,9 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
- "fs4",
  "garudust-core",
  "rusqlite",
- "serde",
- "serde_json",
- "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1943,7 +1916,6 @@ dependencies = [
  "bytes",
  "dashmap 6.2.1",
  "futures",
- "garudust-agent",
  "garudust-core",
  "garudust-memory",
  "hex",
@@ -1955,7 +1927,6 @@ dependencies = [
  "serenity",
  "sha2 0.11.0",
  "teloxide",
- "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tracing",
@@ -2005,7 +1976,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "walkdir",
@@ -2022,9 +1992,7 @@ dependencies = [
  "futures",
  "garudust-core",
  "reqwest",
- "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -5914,7 +5882,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
 ]
 

--- a/crates/garudust-agent/Cargo.toml
+++ b/crates/garudust-agent/Cargo.toml
@@ -17,13 +17,10 @@ garudust-transport = { path = "../garudust-transport", version = "0.9.0" }
 garudust-tools     = { path = "../garudust-tools",     version = "0.9.0" }
 garudust-memory    = { path = "../garudust-memory",    version = "0.9.0" }
 async-trait        = { workspace = true }
-serde              = { workspace = true }
 serde_json         = { workspace = true }
-serde_yaml         = { workspace = true }
 tokio              = { workspace = true }
 tracing            = { workspace = true }
 anyhow             = { workspace = true }
-thiserror          = { workspace = true }
 futures            = { workspace = true }
 uuid               = { workspace = true }
 chrono             = { workspace = true }

--- a/crates/garudust-core/Cargo.toml
+++ b/crates/garudust-core/Cargo.toml
@@ -19,7 +19,6 @@ serde_json  = { workspace = true }
 serde_yaml  = { workspace = true }
 thiserror   = { workspace = true }
 tokio       = { workspace = true }
-uuid        = { workspace = true }
 chrono      = { workspace = true }
 anyhow      = { workspace = true }
 dirs        = "6"

--- a/crates/garudust-cron/Cargo.toml
+++ b/crates/garudust-cron/Cargo.toml
@@ -17,13 +17,8 @@ garudust-agent = { path = "../garudust-agent", version = "0.9.0" }
 tokio-cron-scheduler = { workspace = true }
 async-trait    = { workspace = true }
 uuid           = { workspace = true }
-serde          = { workspace = true }
-serde_json     = { workspace = true }
-serde_yaml     = { workspace = true }
 tokio          = { workspace = true }
 tracing        = { workspace = true }
 anyhow         = { workspace = true }
-thiserror      = { workspace = true }
-fs4            = { workspace = true }
 chrono         = { workspace = true }
 chrono-tz      = { workspace = true }

--- a/crates/garudust-gateway/Cargo.toml
+++ b/crates/garudust-gateway/Cargo.toml
@@ -18,14 +18,12 @@ garudust-memory    = { path = "../garudust-memory", version = "0.9.0" }
 async-trait        = { workspace = true }
 axum               = { workspace = true }
 tower              = { workspace = true }
-tower-http         = { workspace = true }
 serde              = { workspace = true }
 serde_json         = { workspace = true }
 tokio              = { workspace = true }
 tokio-stream       = { workspace = true }
 tracing            = { workspace = true }
 anyhow             = { workspace = true }
-thiserror          = { workspace = true }
 futures            = { workspace = true }
 uuid               = { workspace = true }
 chrono             = { workspace = true }

--- a/crates/garudust-memory/Cargo.toml
+++ b/crates/garudust-memory/Cargo.toml
@@ -15,15 +15,9 @@ categories   = ["development-tools", "database"]
 garudust-core = { path = "../garudust-core", version = "0.9.0" }
 async-trait   = { workspace = true }
 rusqlite      = { workspace = true }
-serde         = { workspace = true }
-serde_json    = { workspace = true }
-serde_yaml    = { workspace = true }
 tokio         = { workspace = true }
 tracing       = { workspace = true }
 anyhow        = { workspace = true }
-thiserror     = { workspace = true }
-fs4           = { workspace = true }
-chrono        = { workspace = true }
 uuid          = { workspace = true }
 
 [dev-dependencies]

--- a/crates/garudust-platforms/Cargo.toml
+++ b/crates/garudust-platforms/Cargo.toml
@@ -24,7 +24,6 @@ all      = ["telegram", "discord", "webhook", "slack", "matrix", "line", "whatsa
 
 [dependencies]
 garudust-core   = { path = "../garudust-core",   version = "0.9.0" }
-garudust-agent  = { path = "../garudust-agent",  version = "0.9.0" }
 garudust-memory = { path = "../garudust-memory", version = "0.9.0", optional = true }
 async-trait    = { workspace = true }
 serde          = { workspace = true }
@@ -32,7 +31,6 @@ serde_json     = { workspace = true }
 tokio          = { workspace = true }
 tracing        = { workspace = true }
 anyhow         = { workspace = true }
-thiserror      = { workspace = true }
 futures        = { workspace = true }
 reqwest        = { workspace = true }
 axum              = { workspace = true, optional = true }
@@ -46,3 +44,7 @@ sha2              = { workspace = true, optional = true }
 base64            = { workspace = true, optional = true }
 hex               = { workspace = true, optional = true }
 bytes             = { workspace = true, optional = true }
+
+[package.metadata.cargo-machete]
+# `anyhow` is referenced only by a no_run doctest in src/lib.rs; machete cannot see it.
+ignored = ["anyhow"]

--- a/crates/garudust-tools/Cargo.toml
+++ b/crates/garudust-tools/Cargo.toml
@@ -20,7 +20,6 @@ serde_json      = { workspace = true }
 tokio           = { workspace = true }
 tracing         = { workspace = true }
 anyhow          = { workspace = true }
-thiserror       = { workspace = true }
 reqwest         = { workspace = true }
 futures         = { workspace = true }
 serde_yaml      = { workspace = true }

--- a/crates/garudust-transport/Cargo.toml
+++ b/crates/garudust-transport/Cargo.toml
@@ -15,12 +15,10 @@ categories   = ["network-programming", "asynchronous"]
 garudust-core = { path = "../garudust-core", version = "0.9.0" }
 async-trait   = { workspace = true }
 reqwest       = { workspace = true }
-serde         = { workspace = true }
 serde_json    = { workspace = true }
 tokio         = { workspace = true }
 tracing       = { workspace = true }
 anyhow        = { workspace = true }
-thiserror     = { workspace = true }
 futures       = { workspace = true }
 async-stream  = { workspace = true }
 chrono        = { workspace = true }


### PR DESCRIPTION
## Summary

- Removed 23 unused workspace dependencies across 8 crates (verified with `cargo-machete` plus a manual grep pass over each crate's `src/` for direct imports and derive-macro attributes).
- Kept `anyhow` in `garudust-platforms` because a `no_run` doctest in `lib.rs` type-checks against `anyhow::Result`; added a `[package.metadata.cargo-machete]` ignore so future scans stay clean.

Removed:
- `garudust-core`: uuid
- `garudust-memory`: chrono, fs4, serde, serde_json, serde_yaml, thiserror
- `garudust-agent`: serde, serde_yaml, thiserror
- `garudust-transport`: serde, thiserror
- `garudust-cron`: fs4, serde, serde_json, serde_yaml, thiserror
- `garudust-platforms`: garudust-agent, thiserror
- `garudust-tools`: thiserror
- `garudust-gateway`: thiserror, tower-http

`Cargo.lock` shrinks by 33 lines as the transitive footprint follows.

## Test plan

- [x] `cargo build --workspace --all-targets`
- [x] `cargo test --workspace` (all groups pass, 0 failures)
- [x] `cargo clippy --workspace --all-targets` with the exact CI flags (`-W pedantic -D warnings` plus the project allow list)
- [x] `cargo fmt --check`
- [x] `cargo machete` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)