### PR TITLE
feat(mcp): HTTP transport + resources/prompts support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `url:` on an `mcp_servers` entry to use HTTP (`command`/`args` are ignored when
   `url` is present); omit `url` for the existing stdio behaviour. Lets Garudust
   consume tools from hosted MCP servers across the network.
+- **MCP resources & prompts** — Garudust now surfaces an MCP server's
+  *resources* and *prompts* primitives, not just its tools. When a connected
+  server advertises the capability, four synthetic tools are registered per
+  server: `<server>_list_resources` / `<server>_read_resource` and
+  `<server>_list_prompts` / `<server>_get_prompt`. Tools that always error are
+  never registered — registration is gated on the server's advertised
+  capabilities.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **MCP streamable-HTTP transport** — MCP servers can now be reached over a
+  remote streamable-HTTP endpoint, not just local stdio subprocesses. Set
+  `url:` on an `mcp_servers` entry to use HTTP (`command`/`args` are ignored when
+  `url` is present); omit `url` for the existing stdio behaviour. Lets Garudust
+  consume tools from hosted MCP servers across the network.
+
 ### Security
 
 - **Browser tool SSRF guard** — the `browser` tool's `navigate` action now runs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1813,7 +1813,7 @@ dependencies = [
  "garudust-tools",
  "garudust-transport",
  "ratatui",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_yaml",
  "tokio",
@@ -1932,7 +1932,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "matrix-sdk",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serenity",
@@ -1981,7 +1981,7 @@ dependencies = [
  "jsonschema",
  "lopdf 0.40.0",
  "pdf-extract",
- "reqwest",
+ "reqwest 0.12.28",
  "rmcp",
  "serde",
  "serde_json",
@@ -2002,7 +2002,7 @@ dependencies = [
  "chrono",
  "futures",
  "garudust-core",
- "reqwest",
+ "reqwest 0.12.28",
  "serde_json",
  "tokio",
  "tracing",
@@ -3141,7 +3141,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "ruma",
  "serde",
  "serde_html_form",
@@ -3556,7 +3556,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -4455,9 +4455,43 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -4493,13 +4527,16 @@ dependencies = [
  "base64",
  "chrono",
  "futures",
+ "http",
  "pastey",
  "pin-project-lite",
  "process-wrap",
+ "reqwest 0.13.4",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5094,7 +5131,7 @@ dependencies = [
  "mime_guess",
  "parking_lot",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.28",
  "rustc-hash",
  "secrecy",
  "serde",
@@ -5277,6 +5314,19 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5476,7 +5526,7 @@ dependencies = [
  "once_cell",
  "pin-project",
  "rc-box",
- "reqwest",
+ "reqwest 0.12.28",
  "rgb",
  "serde",
  "serde_json",
@@ -6521,6 +6571,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,11 @@ teloxide  = { version = "0.17", default-features = false, features = ["macros", 
 serenity  = { version = "0.12", default-features = false, features = ["default_no_backend", "rustls_backend"] }
 
 # MCP
-rmcp = { version = "1", features = ["client", "transport-child-process"] }
+rmcp = { version = "1", features = [
+    "client",
+    "transport-child-process",
+    "transport-streamable-http-client-reqwest",
+] }
 
 # Hot-reload
 arc-swap = "1"

--- a/bin/garudust-server/src/main.rs
+++ b/bin/garudust-server/src/main.rs
@@ -18,8 +18,10 @@ use garudust_platforms::{
     telegram::TelegramAdapter, webhook::WebhookAdapter, whatsapp::WhatsAppAdapter,
 };
 use garudust_tools::{
-    load_script_tools, register_standard_tools, security::docker_available,
-    toolsets::mcp::connect_mcp_server, CronSlot, ToolRegistry,
+    load_script_tools, register_standard_tools,
+    security::docker_available,
+    toolsets::mcp::{connect_mcp_http_server, connect_mcp_server},
+    CronSlot, ToolRegistry,
 };
 use garudust_transport::build_transport;
 use notify::event::ModifyKind;
@@ -206,7 +208,11 @@ async fn attach_mcp_servers(
 ) -> Vec<Box<dyn std::any::Any + Send>> {
     let mut handles: Vec<Box<dyn std::any::Any + Send>> = Vec::new();
     for srv in servers {
-        match connect_mcp_server(&srv.command, &srv.args).await {
+        let conn = match &srv.url {
+            Some(url) => connect_mcp_http_server(url, &srv.name).await,
+            None => connect_mcp_server(&srv.command, &srv.args).await,
+        };
+        match conn {
             Ok((tools, handle)) => {
                 tracing::info!(server = %srv.name, tools = tools.len(), "MCP server connected");
                 for t in tools {

--- a/bin/garudust/src/main.rs
+++ b/bin/garudust/src/main.rs
@@ -17,8 +17,10 @@ use garudust_core::config::McpServerConfig;
 use garudust_core::pricing::estimate_cost_usd;
 use garudust_memory::{DocStore, FileMemoryStore, SessionDb};
 use garudust_tools::{
-    load_script_tools, register_standard_tools, security::docker_available,
-    toolsets::mcp::connect_mcp_server, ToolRegistry,
+    load_script_tools, register_standard_tools,
+    security::docker_available,
+    toolsets::mcp::{connect_mcp_http_server, connect_mcp_server},
+    ToolRegistry,
 };
 use garudust_transport::build_transport;
 use tokio::sync::mpsc;
@@ -258,7 +260,11 @@ async fn attach_mcp_servers(
 ) -> McpHandles {
     let mut handles: McpHandles = Vec::new();
     for srv in servers {
-        match connect_mcp_server(&srv.command, &srv.args).await {
+        let conn = match &srv.url {
+            Some(url) => connect_mcp_http_server(url, &srv.name).await,
+            None => connect_mcp_server(&srv.command, &srv.args).await,
+        };
+        match conn {
             Ok((tools, handle)) => {
                 tracing::info!(server = %srv.name, tools = tools.len(), "MCP server connected");
                 for t in tools {

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -275,9 +275,12 @@ security:
 #     webhook_path: /webhook/whatsapp
 
 # ── MCP servers ───────────────────────────────────────────────────────────────
-# Expose external tool servers via Model Context Protocol.
+# Expose external tool servers via Model Context Protocol. Two transports:
+#   • stdio  — set `command` (+ optional `args`); the server runs as a child process.
+#   • http   — set `url` to a remote streamable-HTTP endpoint. `url` wins if both set.
 
 # mcp_servers:
+#   # stdio transport (local subprocess)
 #   - name: filesystem
 #     command: npx
 #     args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/docs"]
@@ -285,6 +288,10 @@ security:
 #   - name: github
 #     command: npx
 #     args: ["-y", "@modelcontextprotocol/server-github"]
+#
+#   # streamable-HTTP transport (remote server)
+#   - name: remote-tools
+#     url: "https://mcp.example.com/mcp"
 
 # ── Cron ──────────────────────────────────────────────────────────────────────
 

--- a/crates/garudust-core/src/config.rs
+++ b/crates/garudust-core/src/config.rs
@@ -906,12 +906,27 @@ impl Default for PlatformConfig {
     }
 }
 
+/// Configuration for one external MCP server.
+///
+/// Two transports are supported, chosen by which field is set:
+/// - **stdio** (default): set `command` (+ optional `args`); the server is
+///   spawned as a child process and spoken to over stdin/stdout.
+/// - **streamable HTTP**: set `url` to a remote endpoint (e.g.
+///   `https://mcp.example.com/mcp`); `command`/`args` are ignored.
+///
+/// `url` takes precedence when both are present.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServerConfig {
     pub name: String,
+    /// Executable to spawn for a stdio transport. Empty when using `url`.
+    #[serde(default)]
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
+    /// Streamable-HTTP endpoint URL. When set, an HTTP transport is used and
+    /// `command`/`args` are ignored.
+    #[serde(default)]
+    pub url: Option<String>,
 }
 
 /// Per-platform webhook server settings. A `WebhookPlatformConfig` with
@@ -1998,5 +2013,33 @@ providers:
         assert_eq!(backup.key.as_deref(), Some("${GROQ_API_KEY_2}"));
         let local = &cfg.providers["local"];
         assert_eq!(local.url.as_deref(), Some("http://192.168.1.10:8000/v1"));
+    }
+
+    #[test]
+    fn mcp_servers_support_stdio_and_http_transports() {
+        let yaml = r#"
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/docs"]
+  - name: remote-tools
+    url: "https://mcp.example.com/mcp"
+"#;
+        let cfg: AgentConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.mcp_servers.len(), 2);
+
+        // stdio: command + args set, url absent.
+        let stdio = &cfg.mcp_servers[0];
+        assert_eq!(stdio.name, "filesystem");
+        assert_eq!(stdio.command, "npx");
+        assert_eq!(stdio.args.len(), 3);
+        assert!(stdio.url.is_none());
+
+        // http: url set, command defaults to empty (no child process spawned).
+        let http = &cfg.mcp_servers[1];
+        assert_eq!(http.name, "remote-tools");
+        assert_eq!(http.url.as_deref(), Some("https://mcp.example.com/mcp"));
+        assert!(http.command.is_empty());
+        assert!(http.args.is_empty());
     }
 }

--- a/crates/garudust-tools/src/toolsets/mcp.rs
+++ b/crates/garudust-tools/src/toolsets/mcp.rs
@@ -91,7 +91,6 @@ impl Tool for McpProxyTool {
     }
 }
 
-/// Connect to an MCP server via stdio and return discovered tools plus an opaque
 fn is_valid_mcp_tool_name(name: &str) -> bool {
     !name.is_empty()
         && name.len() <= 128
@@ -100,23 +99,18 @@ fn is_valid_mcp_tool_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
-/// keep-alive handle. The caller must hold the handle for the lifetime of the tools.
-pub async fn connect_mcp_server(
-    command: &str,
-    args: &[String],
-) -> anyhow::Result<(Vec<Arc<McpProxyTool>>, Box<dyn std::any::Any + Send>)> {
-    use rmcp::{transport::TokioChildProcess, ServiceExt};
+/// An opaque keep-alive handle. The caller must hold it for the lifetime of the
+/// returned tools — dropping it tears down the MCP connection (and, for stdio,
+/// kills the child process).
+type McpConnection = (Vec<Arc<McpProxyTool>>, Box<dyn std::any::Any + Send>);
 
-    let mut cmd = tokio::process::Command::new(command);
-    cmd.args(args)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit());
-
-    let transport = TokioChildProcess::new(cmd)?;
-    let service: rmcp::service::RunningService<RoleClient, ()> = ().serve(transport).await?;
+/// Discover an already-initialized MCP service's tools, wrapping each as an
+/// `McpProxyTool`. Shared by every transport.
+async fn collect_tools(
+    service: rmcp::service::RunningService<RoleClient, ()>,
+    server_name: String,
+) -> anyhow::Result<McpConnection> {
     let peer = service.peer().clone();
-    let server_name = command.to_string();
 
     let mcp_tools: Vec<Arc<McpProxyTool>> = service
         .list_all_tools()
@@ -143,4 +137,34 @@ pub async fn connect_mcp_server(
         .collect();
 
     Ok((mcp_tools, Box::new(service)))
+}
+
+/// Connect to an MCP server over **stdio** by spawning `command` as a child
+/// process, and return its discovered tools plus a keep-alive handle.
+pub async fn connect_mcp_server(command: &str, args: &[String]) -> anyhow::Result<McpConnection> {
+    use rmcp::{transport::TokioChildProcess, ServiceExt};
+
+    let mut cmd = tokio::process::Command::new(command);
+    cmd.args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit());
+
+    let transport = TokioChildProcess::new(cmd)?;
+    let service: rmcp::service::RunningService<RoleClient, ()> = ().serve(transport).await?;
+    collect_tools(service, command.to_string()).await
+}
+
+/// Connect to a remote MCP server over **streamable HTTP** at `url`, and return
+/// its discovered tools plus a keep-alive handle. `server_name` labels the
+/// resulting tools' toolset (typically the configured server name).
+pub async fn connect_mcp_http_server(
+    url: &str,
+    server_name: &str,
+) -> anyhow::Result<McpConnection> {
+    use rmcp::{transport::StreamableHttpClientTransport, ServiceExt};
+
+    let transport = StreamableHttpClientTransport::from_uri(url);
+    let service: rmcp::service::RunningService<RoleClient, ()> = ().serve(transport).await?;
+    collect_tools(service, server_name.to_string()).await
 }

--- a/crates/garudust-tools/src/toolsets/mcp.rs
+++ b/crates/garudust-tools/src/toolsets/mcp.rs
@@ -7,10 +7,13 @@ use garudust_core::{
     types::ToolResult,
 };
 use rmcp::{
-    model::CallToolRequestParams,
+    model::{
+        CallToolRequestParams, GetPromptRequestParams, PromptMessageContent, PromptMessageRole,
+        ReadResourceRequestParams, ResourceContents,
+    },
     service::{Peer, RoleClient},
 };
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 /// Wraps a single tool exposed by an external MCP server.
 pub struct McpProxyTool {
@@ -91,6 +94,250 @@ impl Tool for McpProxyTool {
     }
 }
 
+/// The MCP primitives beyond tool calls — resource and prompt access — that we
+/// surface to the model as synthetic tools.
+#[derive(Clone, Copy)]
+enum McpOp {
+    ListResources,
+    ReadResource,
+    ListPrompts,
+    GetPrompt,
+}
+
+/// Exposes an MCP server's resource/prompt primitives to the model as a tool.
+/// One instance per (server, operation); registered only when the server
+/// advertises the matching capability in its initialize response.
+pub struct McpMetaTool {
+    name: String,
+    description: String,
+    schema: Value,
+    server_name: String,
+    op: McpOp,
+    peer: Peer<RoleClient>,
+}
+
+impl McpMetaTool {
+    fn new(op: McpOp, server_name: &str, peer: Peer<RoleClient>) -> Self {
+        let prefix = sanitize_ident(server_name);
+        let (suffix, description, schema) = match op {
+            McpOp::ListResources => (
+                "list_resources",
+                format!("List resources exposed by the '{server_name}' MCP server (uri, name, description). Use {prefix}_read_resource to fetch one."),
+                json!({ "type": "object", "properties": {} }),
+            ),
+            McpOp::ReadResource => (
+                "read_resource",
+                format!("Read the contents of a resource from the '{server_name}' MCP server by URI."),
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "uri": { "type": "string", "description": "Resource URI, as returned by list_resources" }
+                    },
+                    "required": ["uri"]
+                }),
+            ),
+            McpOp::ListPrompts => (
+                "list_prompts",
+                format!("List prompt templates exposed by the '{server_name}' MCP server (name, description, arguments). Use {prefix}_get_prompt to render one."),
+                json!({ "type": "object", "properties": {} }),
+            ),
+            McpOp::GetPrompt => (
+                "get_prompt",
+                format!("Fetch a rendered prompt template from the '{server_name}' MCP server by name."),
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "description": "Prompt name, as returned by list_prompts" },
+                        "arguments": { "type": "object", "description": "Optional template arguments (name → value)" }
+                    },
+                    "required": ["name"]
+                }),
+            ),
+        };
+        Self {
+            name: format!("{prefix}_{suffix}"),
+            description,
+            schema,
+            server_name: server_name.to_string(),
+            op,
+            peer,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpMetaTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn toolset(&self) -> &str {
+        &self.server_name
+    }
+
+    fn schema(&self) -> Value {
+        self.schema.clone()
+    }
+
+    async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        match self.op {
+            McpOp::ListResources => {
+                let resources = self
+                    .peer
+                    .list_all_resources()
+                    .await
+                    .map_err(|e| ToolError::Execution(e.to_string()))?;
+                if resources.is_empty() {
+                    return Ok(ToolResult::ok(&self.name, "(no resources)".to_string()));
+                }
+                let text = resources
+                    .iter()
+                    .map(|r| {
+                        let desc = r
+                            .description
+                            .as_deref()
+                            .map(|d| format!(": {d}"))
+                            .unwrap_or_default();
+                        let mime = r
+                            .mime_type
+                            .as_deref()
+                            .map(|m| format!(" [{m}]"))
+                            .unwrap_or_default();
+                        format!("{} — {}{desc}{mime}", r.uri, r.name)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(ToolResult::ok(&self.name, text))
+            }
+
+            McpOp::ReadResource => {
+                let uri = params["uri"].as_str().ok_or_else(|| {
+                    ToolError::InvalidArgs("uri required for read_resource".into())
+                })?;
+                let result = self
+                    .peer
+                    .read_resource(ReadResourceRequestParams::new(uri))
+                    .await
+                    .map_err(|e| ToolError::Execution(e.to_string()))?;
+                let text = result
+                    .contents
+                    .iter()
+                    .map(|c| match c {
+                        ResourceContents::TextResourceContents { text, .. } => text.clone(),
+                        ResourceContents::BlobResourceContents {
+                            blob, mime_type, ..
+                        } => format!(
+                            "[binary resource, {} base64 bytes{}]",
+                            blob.len(),
+                            mime_type
+                                .as_deref()
+                                .map(|m| format!(", {m}"))
+                                .unwrap_or_default()
+                        ),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(ToolResult::ok(&self.name, text))
+            }
+
+            McpOp::ListPrompts => {
+                let prompts = self
+                    .peer
+                    .list_all_prompts()
+                    .await
+                    .map_err(|e| ToolError::Execution(e.to_string()))?;
+                if prompts.is_empty() {
+                    return Ok(ToolResult::ok(&self.name, "(no prompts)".to_string()));
+                }
+                let text = prompts
+                    .iter()
+                    .map(|p| {
+                        let desc = p
+                            .description
+                            .as_deref()
+                            .map(|d| format!(": {d}"))
+                            .unwrap_or_default();
+                        let args = p
+                            .arguments
+                            .as_ref()
+                            .map(|a| {
+                                let names = a
+                                    .iter()
+                                    .map(|arg| arg.name.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                format!(" (args: {names})")
+                            })
+                            .unwrap_or_default();
+                        format!("{}{desc}{args}", p.name)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(ToolResult::ok(&self.name, text))
+            }
+
+            McpOp::GetPrompt => {
+                let name = params["name"]
+                    .as_str()
+                    .ok_or_else(|| ToolError::InvalidArgs("name required for get_prompt".into()))?;
+                let mut req = GetPromptRequestParams::new(name);
+                if let Some(args) = params.get("arguments").and_then(Value::as_object) {
+                    req = req.with_arguments(args.clone());
+                }
+                let result = self
+                    .peer
+                    .get_prompt(req)
+                    .await
+                    .map_err(|e| ToolError::Execution(e.to_string()))?;
+                let text = result
+                    .messages
+                    .iter()
+                    .map(|m| {
+                        let role = match m.role {
+                            PromptMessageRole::User => "user",
+                            PromptMessageRole::Assistant => "assistant",
+                        };
+                        let body = match &m.content {
+                            PromptMessageContent::Text { text } => text.clone(),
+                            _ => "[non-text content]".to_string(),
+                        };
+                        format!("[{role}] {body}")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(ToolResult::ok(&self.name, text))
+            }
+        }
+    }
+}
+
+/// Turn an arbitrary MCP server label into a tool-name-safe prefix
+/// (alphanumeric / `_` / `-`). Used so resource/prompt meta-tools get stable,
+/// API-valid names even when the server is launched via a path-like command.
+fn sanitize_ident(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(48)
+        .collect();
+    let trimmed = cleaned.trim_matches('_');
+    if trimmed.is_empty() {
+        "mcp".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 fn is_valid_mcp_tool_name(name: &str) -> bool {
     !name.is_empty()
         && name.len() <= 128
@@ -102,17 +349,19 @@ fn is_valid_mcp_tool_name(name: &str) -> bool {
 /// An opaque keep-alive handle. The caller must hold it for the lifetime of the
 /// returned tools — dropping it tears down the MCP connection (and, for stdio,
 /// kills the child process).
-type McpConnection = (Vec<Arc<McpProxyTool>>, Box<dyn std::any::Any + Send>);
+type McpConnection = (Vec<Arc<dyn Tool>>, Box<dyn std::any::Any + Send>);
 
-/// Discover an already-initialized MCP service's tools, wrapping each as an
-/// `McpProxyTool`. Shared by every transport.
+/// Discover an already-initialized MCP service's primitives, wrapping each as a
+/// `Tool` the agent can call. Tools become `McpProxyTool`s; resource and prompt
+/// access is surfaced as `McpMetaTool`s, but only for the primitives the server
+/// actually advertises in its initialize response. Shared by every transport.
 async fn collect_tools(
     service: rmcp::service::RunningService<RoleClient, ()>,
     server_name: String,
 ) -> anyhow::Result<McpConnection> {
     let peer = service.peer().clone();
 
-    let mcp_tools: Vec<Arc<McpProxyTool>> = service
+    let mut tools: Vec<Arc<dyn Tool>> = service
         .list_all_tools()
         .await?
         .into_iter()
@@ -132,11 +381,42 @@ async fn collect_tools(
                 input_schema,
                 server_name.clone(),
                 peer.clone(),
-            )) as Arc<McpProxyTool>)
+            )) as Arc<dyn Tool>)
         })
         .collect();
 
-    Ok((mcp_tools, Box::new(service)))
+    // Surface resource/prompt primitives as meta-tools, gated on the server's
+    // advertised capabilities so we never register a tool that always errors.
+    let caps = service.peer_info().map(|info| &info.capabilities);
+    let has_resources = caps.is_some_and(|c| c.resources.is_some());
+    let has_prompts = caps.is_some_and(|c| c.prompts.is_some());
+
+    if has_resources {
+        tools.push(Arc::new(McpMetaTool::new(
+            McpOp::ListResources,
+            &server_name,
+            peer.clone(),
+        )));
+        tools.push(Arc::new(McpMetaTool::new(
+            McpOp::ReadResource,
+            &server_name,
+            peer.clone(),
+        )));
+    }
+    if has_prompts {
+        tools.push(Arc::new(McpMetaTool::new(
+            McpOp::ListPrompts,
+            &server_name,
+            peer.clone(),
+        )));
+        tools.push(Arc::new(McpMetaTool::new(
+            McpOp::GetPrompt,
+            &server_name,
+            peer.clone(),
+        )));
+    }
+
+    Ok((tools, Box::new(service)))
 }
 
 /// Connect to an MCP server over **stdio** by spawning `command` as a child
@@ -167,4 +447,46 @@ pub async fn connect_mcp_http_server(
     let transport = StreamableHttpClientTransport::from_uri(url);
     let service: rmcp::service::RunningService<RoleClient, ()> = ().serve(transport).await?;
     collect_tools(service, server_name.to_string()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_ident_keeps_valid_chars() {
+        assert_eq!(sanitize_ident("github"), "github");
+        assert_eq!(sanitize_ident("remote-tools"), "remote-tools");
+        assert_eq!(sanitize_ident("my_server_1"), "my_server_1");
+    }
+
+    #[test]
+    fn sanitize_ident_replaces_path_and_special_chars() {
+        // A path-like stdio command must still yield a tool-name-safe prefix.
+        assert_eq!(sanitize_ident("/usr/bin/npx"), "usr_bin_npx");
+        assert_eq!(sanitize_ident("npx @scope/pkg"), "npx__scope_pkg");
+    }
+
+    #[test]
+    fn sanitize_ident_falls_back_when_empty() {
+        assert_eq!(sanitize_ident(""), "mcp");
+        assert_eq!(sanitize_ident("///"), "mcp");
+        assert_eq!(sanitize_ident("___"), "mcp");
+    }
+
+    #[test]
+    fn sanitize_ident_truncates_long_input() {
+        let long = "a".repeat(100);
+        assert_eq!(sanitize_ident(&long).len(), 48);
+    }
+
+    #[test]
+    fn is_valid_mcp_tool_name_rules() {
+        assert!(is_valid_mcp_tool_name("read_file"));
+        assert!(is_valid_mcp_tool_name("tool-1"));
+        assert!(!is_valid_mcp_tool_name(""));
+        assert!(!is_valid_mcp_tool_name("has space"));
+        assert!(!is_valid_mcp_tool_name("has/slash"));
+        assert!(!is_valid_mcp_tool_name(&"x".repeat(129)));
+    }
 }


### PR DESCRIPTION
Brings Garudust's MCP client up to parity with hosted-MCP-capable agents on two axes: **transport reach** and **protocol primitives**. Two commits:

## 1. Streamable-HTTP transport

Before: MCP servers could only be spawned as **local stdio child processes** (`transport-child-process`). Now Garudust also speaks the official `rmcp` **streamable-HTTP** client transport (`transport-streamable-http-client-reqwest`, reusing the existing reqwest + rustls stack).

`McpServerConfig` gains an optional `url`:

```yaml
mcp_servers:
  - name: filesystem            # stdio (unchanged)
    command: npx
    args: ["-y", "@modelcontextprotocol/server-filesystem", "/docs"]
  - name: remote-tools          # streamable HTTP (new)
    url: "https://mcp.example.com/mcp"
```

`url` set → HTTP (`command`/`args` ignored); `url` absent → existing stdio behaviour. Fully backward compatible (`command` is now `#[serde(default)]`).

**Security note:** no `net_guard` SSRF check here by design — MCP endpoints are operator-configured (not LLM-controlled), and local servers on `127.0.0.1` are the normal case.

## 2. Resources & prompts

Before: only a server's `tools` were proxied; its `resources` and `prompts` primitives were ignored. Now an `McpMetaTool` surfaces both to the model as synthetic tools, **registered per server and gated on advertised capabilities** (a tool that would always error is never registered):

- resources → `<server>_list_resources`, `<server>_read_resource`
- prompts   → `<server>_list_prompts`, `<server>_get_prompt`

`collect_tools` now returns `Vec<Arc<dyn Tool>>` (mixed proxy + meta tools). Server labels go through `sanitize_ident`, so a path-like stdio command (`/usr/bin/npx`) still yields an API-valid tool-name prefix.

## Tests / verification

- New: `mcp_servers_support_stdio_and_http_transports`, `sanitize_ident_*` (4), `is_valid_mcp_tool_name_rules`
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets` (CI flags, pedantic) ✅ no warnings
- `cargo test --workspace` ✅ all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)