### PR TITLE
feat(install): one-line installers for macOS/Linux/Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **One-line installers** — `scripts/install.sh` (macOS & Linux, all archs incl.
+  ARM / Raspberry Pi / WSL) and `scripts/install.ps1` (Windows). Both detect the
+  OS/arch, resolve the latest release, verify the SHA-256 checksum, and install
+  `garudust` + `garudust-server`; `GARUDUST_VERSION` and `GARUDUST_BIN_DIR`
+  override the version and destination. Replaces the previous manual snippet,
+  which extracted into a versioned subdirectory and so failed to move the
+  binaries onto `PATH`.
 - **MCP streamable-HTTP transport** — MCP servers can now be reached over a
   remote streamable-HTTP endpoint, not just local stdio subprocesses. Set
   `url:` on an `mcp_servers` entry to use HTTP (`command`/`args` are ignored when

--- a/README.md
+++ b/README.md
@@ -30,19 +30,11 @@ A self-improving AI agent runtime written in Rust — ~10 MB binary, no runtime 
 
 **01 — Install**
 
-**macOS & Linux** (all archs, incl. ARM / Raspberry Pi / WSL):
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
 ```
 
-**Windows** (PowerShell):
-
-```powershell
-irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
-```
-
-The installer detects your OS/arch, verifies the release checksum, and installs `garudust` + `garudust-server`. Pin a version with `GARUDUST_VERSION=v0.13.1` or change the target dir with `GARUDUST_BIN_DIR=~/.local/bin`.
+macOS & Linux, any arch (ARM, Raspberry Pi, WSL). Windows: `irm .../scripts/install.ps1 | iex`. Override with `GARUDUST_VERSION` / `GARUDUST_BIN_DIR`.
 
 <details>
 <summary>Manual download or build from source</summary>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,24 @@ A self-improving AI agent runtime written in Rust — ~10 MB binary, no runtime 
 
 **01 — Install**
 
-Download a pre-built binary from [GitHub Releases](https://github.com/garudust-org/garudust-agent/releases/latest):
+**macOS & Linux** (all archs, incl. ARM / Raspberry Pi / WSL):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
+```
+
+**Windows** (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
+```
+
+The installer detects your OS/arch, verifies the release checksum, and installs `garudust` + `garudust-server`. Pin a version with `GARUDUST_VERSION=v0.13.1` or change the target dir with `GARUDUST_BIN_DIR=~/.local/bin`.
+
+<details>
+<summary>Manual download or build from source</summary>
+
+Grab a pre-built binary from [GitHub Releases](https://github.com/garudust-org/garudust-agent/releases/latest):
 
 | OS | Architecture | Binary |
 |----|-------------|--------|
@@ -40,15 +57,9 @@ Download a pre-built binary from [GitHub Releases](https://github.com/garudust-o
 | Linux | ARM64 (Raspberry Pi 4/5, Jetson) | `garudust-*-aarch64-unknown-linux-musl.tar.gz` |
 | Windows | x86_64 | `garudust-*-x86_64-pc-windows-msvc.zip` |
 
-```bash
-ARCH=$(uname -m)
-[ "$ARCH" = "aarch64" ] && TARGET="aarch64-unknown-linux-musl" || TARGET="x86_64-unknown-linux-musl"
-VER=$(curl -s https://api.github.com/repos/garudust-org/garudust-agent/releases/latest | grep tag_name | cut -d'"' -f4)
-curl -LO "https://github.com/garudust-org/garudust-agent/releases/latest/download/garudust-${VER}-${TARGET}.tar.gz"
-tar -xzf garudust-*.tar.gz && sudo mv garudust garudust-server /usr/local/bin/
-```
-
 Or build from source (Rust 1.87+): `git clone https://github.com/garudust-org/garudust-agent && cargo build --release`
+
+</details>
 
 ---
 

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -30,19 +30,11 @@ AI agent runtime แบบ self-improving เขียนด้วย Rust — b
 
 **01 — ติดตั้ง**
 
-**macOS & Linux** (ทุกสถาปัตยกรรม รวม ARM / Raspberry Pi / WSL):
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
 ```
 
-**Windows** (PowerShell):
-
-```powershell
-irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
-```
-
-ตัวติดตั้งจะตรวจ OS/arch อัตโนมัติ ตรวจ checksum ของ release แล้วติดตั้ง `garudust` + `garudust-server` ปักหมุดเวอร์ชันด้วย `GARUDUST_VERSION=v0.13.1` หรือเปลี่ยนปลายทางด้วย `GARUDUST_BIN_DIR=~/.local/bin`
+macOS & Linux ทุก arch (ARM, Raspberry Pi, WSL) — Windows: `irm .../scripts/install.ps1 | iex` ปรับแต่งด้วย `GARUDUST_VERSION` / `GARUDUST_BIN_DIR`
 
 <details>
 <summary>ดาวน์โหลดเองหรือ build จาก source</summary>

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -30,6 +30,23 @@ AI agent runtime แบบ self-improving เขียนด้วย Rust — b
 
 **01 — ติดตั้ง**
 
+**macOS & Linux** (ทุกสถาปัตยกรรม รวม ARM / Raspberry Pi / WSL):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
+```
+
+**Windows** (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
+```
+
+ตัวติดตั้งจะตรวจ OS/arch อัตโนมัติ ตรวจ checksum ของ release แล้วติดตั้ง `garudust` + `garudust-server` ปักหมุดเวอร์ชันด้วย `GARUDUST_VERSION=v0.13.1` หรือเปลี่ยนปลายทางด้วย `GARUDUST_BIN_DIR=~/.local/bin`
+
+<details>
+<summary>ดาวน์โหลดเองหรือ build จาก source</summary>
+
 ดาวน์โหลด binary สำเร็จรูปจาก [GitHub Releases](https://github.com/garudust-org/garudust-agent/releases/latest):
 
 | OS | สถาปัตยกรรม | ไฟล์ |
@@ -40,15 +57,9 @@ AI agent runtime แบบ self-improving เขียนด้วย Rust — b
 | Linux | ARM64 (Raspberry Pi 4/5, Jetson) | `garudust-*-aarch64-unknown-linux-musl.tar.gz` |
 | Windows | x86_64 | `garudust-*-x86_64-pc-windows-msvc.zip` |
 
-```bash
-ARCH=$(uname -m)
-[ "$ARCH" = "aarch64" ] && TARGET="aarch64-unknown-linux-musl" || TARGET="x86_64-unknown-linux-musl"
-VER=$(curl -s https://api.github.com/repos/garudust-org/garudust-agent/releases/latest | grep tag_name | cut -d'"' -f4)
-curl -LO "https://github.com/garudust-org/garudust-agent/releases/latest/download/garudust-${VER}-${TARGET}.tar.gz"
-tar -xzf garudust-*.tar.gz && sudo mv garudust garudust-server /usr/local/bin/
-```
-
 หรือ build จาก source (Rust 1.87+): `git clone https://github.com/garudust-org/garudust-agent && cargo build --release`
+
+</details>
 
 ---
 

--- a/docs/i18n/zh/README.md
+++ b/docs/i18n/zh/README.md
@@ -30,6 +30,23 @@
 
 **01 — 安装**
 
+**macOS 和 Linux**（所有架构，包括 ARM / Raspberry Pi / WSL）：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
+```
+
+**Windows**（PowerShell）：
+
+```powershell
+irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
+```
+
+安装脚本会自动检测操作系统/架构、校验 release 校验和，并安装 `garudust` + `garudust-server`。用 `GARUDUST_VERSION=v0.13.1` 锁定版本，或用 `GARUDUST_BIN_DIR=~/.local/bin` 更改安装目录。
+
+<details>
+<summary>手动下载或从源码构建</summary>
+
 从 [GitHub Releases](https://github.com/garudust-org/garudust-agent/releases/latest) 下载预构建 binary：
 
 | 操作系统 | 架构 | 文件 |
@@ -40,15 +57,9 @@
 | Linux | ARM64（Raspberry Pi 4/5、Jetson） | `garudust-*-aarch64-unknown-linux-musl.tar.gz` |
 | Windows | x86_64 | `garudust-*-x86_64-pc-windows-msvc.zip` |
 
-```bash
-ARCH=$(uname -m)
-[ "$ARCH" = "aarch64" ] && TARGET="aarch64-unknown-linux-musl" || TARGET="x86_64-unknown-linux-musl"
-VER=$(curl -s https://api.github.com/repos/garudust-org/garudust-agent/releases/latest | grep tag_name | cut -d'"' -f4)
-curl -LO "https://github.com/garudust-org/garudust-agent/releases/latest/download/garudust-${VER}-${TARGET}.tar.gz"
-tar -xzf garudust-*.tar.gz && sudo mv garudust garudust-server /usr/local/bin/
-```
-
 或从源码构建（需 Rust 1.87+）：`git clone https://github.com/garudust-org/garudust-agent && cargo build --release`
+
+</details>
 
 ---
 

--- a/docs/i18n/zh/README.md
+++ b/docs/i18n/zh/README.md
@@ -30,19 +30,11 @@
 
 **01 — 安装**
 
-**macOS 和 Linux**（所有架构，包括 ARM / Raspberry Pi / WSL）：
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
 ```
 
-**Windows**（PowerShell）：
-
-```powershell
-irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
-```
-
-安装脚本会自动检测操作系统/架构、校验 release 校验和，并安装 `garudust` + `garudust-server`。用 `GARUDUST_VERSION=v0.13.1` 锁定版本，或用 `GARUDUST_BIN_DIR=~/.local/bin` 更改安装目录。
+macOS 和 Linux，所有架构（ARM、Raspberry Pi、WSL）。Windows：`irm .../scripts/install.ps1 | iex`。用 `GARUDUST_VERSION` / `GARUDUST_BIN_DIR` 自定义。
 
 <details>
 <summary>手动下载或从源码构建</summary>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+  Garudust installer for Windows (x86_64).
+
+.EXAMPLE
+  irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
+
+.NOTES
+  Overrides via environment variables:
+    GARUDUST_VERSION   pin a release tag (e.g. v0.13.1); default: latest
+    GARUDUST_BIN_DIR   install destination; default: %LOCALAPPDATA%\Programs\garudust
+#>
+
+$ErrorActionPreference = 'Stop'
+$repo = 'garudust-org/garudust-agent'
+
+function Info($m) { Write-Host "==> $m" -ForegroundColor Cyan }
+function Die($m)  { Write-Host "error: $m" -ForegroundColor Red; exit 1 }
+
+# ── Detect architecture ──────────────────────────────────────────────────────
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($arch -ne 'AMD64') {
+  Die "unsupported architecture '$arch'. Only x86_64 Windows binaries are published."
+}
+$target = 'x86_64-pc-windows-msvc'
+
+# ── Resolve version ──────────────────────────────────────────────────────────
+$version = $env:GARUDUST_VERSION
+if (-not $version) {
+  Info 'Resolving latest release...'
+  $rel = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
+  $version = $rel.tag_name
+  if (-not $version) { Die 'could not determine the latest version. Set GARUDUST_VERSION.' }
+}
+
+$asset = "garudust-$version-$target.zip"
+$url   = "https://github.com/$repo/releases/download/$version/$asset"
+
+# ── Download ─────────────────────────────────────────────────────────────────
+$tmp = Join-Path $env:TEMP ("garudust-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tmp | Out-Null
+try {
+  Info "Downloading $asset..."
+  $zip = Join-Path $tmp $asset
+  Invoke-WebRequest -Uri $url -OutFile $zip
+
+  # ── Verify checksum (best-effort) ──────────────────────────────────────────
+  try {
+    $sums = (Invoke-WebRequest "https://github.com/$repo/releases/download/$version/SHA256SUMS.txt").Content
+    $line = ($sums -split "`n" | Where-Object { $_ -match [regex]::Escape($asset) } | Select-Object -First 1)
+    if ($line) {
+      $expected = ($line -split '\s+')[0]
+      $actual   = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+      if ($actual -ne $expected.ToLower()) { Die "checksum mismatch for $asset." }
+      Info 'Checksum verified.'
+    }
+  } catch { Write-Host "warning: skipping checksum verification." -ForegroundColor Yellow }
+
+  # ── Extract ──────────────────────────────────────────────────────────────────
+  Expand-Archive -Path $zip -DestinationPath $tmp -Force
+  $src = Join-Path $tmp "garudust-$version-$target"
+
+  # ── Install ──────────────────────────────────────────────────────────────────
+  $binDir = $env:GARUDUST_BIN_DIR
+  if (-not $binDir) { $binDir = Join-Path $env:LOCALAPPDATA 'Programs\garudust' }
+  New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+  foreach ($b in 'garudust.exe', 'garudust-server.exe') {
+    Copy-Item (Join-Path $src $b) (Join-Path $binDir $b) -Force
+  }
+  Info "Installed garudust $version -> $binDir"
+
+  # ── PATH ─────────────────────────────────────────────────────────────────────
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  if ($userPath -notlike "*$binDir*") {
+    [Environment]::SetEnvironmentVariable('Path', "$userPath;$binDir", 'User')
+    Write-Host "Added $binDir to your user PATH. Restart your shell to pick it up." -ForegroundColor Yellow
+  }
+  Info "Run 'garudust setup' to get started."
+}
+finally {
+  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env sh
+# Garudust installer — macOS & Linux (all archs, incl. ARM / Raspberry Pi / WSL).
+#
+#   curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
+#
+# Environment overrides:
+#   GARUDUST_VERSION   pin a release tag (e.g. v0.13.1); default: latest
+#   GARUDUST_BIN_DIR   install destination; default: /usr/local/bin (or ~/.local/bin)
+#
+# POSIX sh — no bashisms, so it runs under sh, bash, dash, zsh, busybox.
+set -eu
+
+REPO="garudust-org/garudust-agent"
+
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
+warn()  { printf '\033[1;33mwarning:\033[0m %s\n' "$1" >&2; }
+die()   { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
+have()  { command -v "$1" >/dev/null 2>&1; }
+
+# ── Detect platform ──────────────────────────────────────────────────────────
+os="$(uname -s)"
+arch="$(uname -m)"
+
+case "$os" in
+  Darwin) os_name="apple-darwin" ;;
+  Linux)  os_name="unknown-linux-musl" ;;
+  *)      die "unsupported OS '$os'. On Windows use the PowerShell installer (install.ps1)." ;;
+esac
+
+case "$arch" in
+  x86_64 | amd64)  cpu="x86_64" ;;
+  arm64 | aarch64) cpu="aarch64" ;;
+  *)               die "unsupported architecture '$arch'." ;;
+esac
+
+target="${cpu}-${os_name}"
+
+# ── Resolve version ──────────────────────────────────────────────────────────
+have curl || die "curl is required."
+have tar  || die "tar is required."
+
+version="${GARUDUST_VERSION:-}"
+if [ -z "$version" ]; then
+  info "Resolving latest release…"
+  version="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4)"
+  [ -n "$version" ] || die "could not determine the latest version. Set GARUDUST_VERSION."
+fi
+
+asset="garudust-${version}-${target}.tar.gz"
+url="https://github.com/${REPO}/releases/download/${version}/${asset}"
+
+# ── Download ─────────────────────────────────────────────────────────────────
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+info "Downloading ${asset}…"
+curl -fSL --progress-bar "$url" -o "$tmp/$asset" \
+  || die "download failed: $url (does a release exist for ${target}?)"
+
+# ── Verify checksum (best-effort) ────────────────────────────────────────────
+sums_url="https://github.com/${REPO}/releases/download/${version}/SHA256SUMS.txt"
+if curl -fsSL "$sums_url" -o "$tmp/SHA256SUMS.txt" 2>/dev/null; then
+  expected="$(grep " ${asset}\$" "$tmp/SHA256SUMS.txt" | awk '{print $1}' | head -1)"
+  if [ -n "$expected" ]; then
+    if have sha256sum;  then actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+    elif have shasum;   then actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+    else actual=""; warn "no sha256 tool found; skipping checksum verification."
+    fi
+    if [ -n "$actual" ] && [ "$actual" != "$expected" ]; then
+      die "checksum mismatch for ${asset} (expected ${expected}, got ${actual})."
+    fi
+    [ -n "$actual" ] && info "Checksum verified."
+  fi
+else
+  warn "SHA256SUMS.txt not found for ${version}; skipping checksum verification."
+fi
+
+# ── Extract ──────────────────────────────────────────────────────────────────
+tar -xzf "$tmp/$asset" -C "$tmp"
+src="$tmp/garudust-${version}-${target}"
+[ -f "$src/garudust" ] || die "archive layout unexpected: $src/garudust not found."
+
+# ── Choose install dir ───────────────────────────────────────────────────────
+sudo=""
+bin_dir="${GARUDUST_BIN_DIR:-}"
+if [ -z "$bin_dir" ]; then
+  if [ -w /usr/local/bin ] 2>/dev/null; then
+    bin_dir="/usr/local/bin"
+  elif have sudo; then
+    bin_dir="/usr/local/bin"; sudo="sudo"
+  else
+    bin_dir="$HOME/.local/bin"
+  fi
+fi
+
+if [ "$sudo" = "sudo" ]; then
+  info "Installing to ${bin_dir} (requires sudo)…"
+else
+  info "Installing to ${bin_dir}…"
+fi
+
+$sudo mkdir -p "$bin_dir"
+for b in garudust garudust-server; do
+  $sudo install -m 0755 "$src/$b" "$bin_dir/$b"
+done
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+info "Installed garudust ${version} → ${bin_dir}"
+case ":${PATH}:" in
+  *":${bin_dir}:"*) ;;
+  *) warn "${bin_dir} is not on your PATH. Add it, e.g.:"
+     printf '       export PATH="%s:$PATH"\n' "$bin_dir" ;;
+esac
+
+if have garudust; then
+  printf '\n'
+  garudust --version 2>/dev/null || true
+  info "Run 'garudust setup' to get started."
+fi


### PR DESCRIPTION
## What

Adds short, Hermes-style one-line installers:

```bash
# macOS & Linux (all archs, incl. ARM / Raspberry Pi / WSL)
curl -fsSL https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.sh | sh
```
```powershell
# Windows
irm https://raw.githubusercontent.com/garudust-org/garudust-agent/main/scripts/install.ps1 | iex
```

Each script: detects OS/arch → resolves the latest release (or `GARUDUST_VERSION`) → **verifies the published SHA-256 checksum** → extracts → installs `garudust` + `garudust-server` to `/usr/local/bin` (or `GARUDUST_BIN_DIR` / `%LOCALAPPDATA%\Programs\garudust`).

## Why

The old README snippet was **broken**: release tarballs extract into a `garudust-<ver>-<target>/` subdirectory, but the snippet ran `mv garudust garudust-server /usr/local/bin/` from the CWD — the binaries were never there. The new scripts handle the subdirectory, checksum, PATH detection, and arch mapping correctly.

## OS coverage

| Platform | Method |
|---|---|
| macOS (arm64 / x86_64) | `install.sh` ✅ |
| Linux (x86_64 / aarch64, incl. RPi, musl static) | `install.sh` ✅ |
| WSL | `install.sh` ✅ |
| Windows (x86_64) | `install.ps1` ✅ |

`curl \| sh` can't run on native Windows (no bash), so Windows gets a matching PowerShell `irm \| iex` one-liner. Arch/target mapping matches `release.yml` exactly.

## Verification

- `install.sh`: `sh -n` syntax check ✅, and run **end-to-end against the real v0.13.1 release** — resolved latest, downloaded `aarch64-apple-darwin`, checksum **verified**, extracted from the subdir, installed both binaries, `garudust --version` → `garudust 0.13.1` ✅
- README updated in all 3 locales (en/th/zh): one-liners up top, binary table + source build collapsed below.
- No Rust changed; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)