### PR TITLE
fix(gateway): prevent image-gate self-deadlock on text+image messages

### DIFF
--- a/crates/garudust-gateway/src/handler.rs
+++ b/crates/garudust-gateway/src/handler.rs
@@ -1239,12 +1239,20 @@ impl MessageHandler for GatewayHandler {
         // model sees only the "[analysing…]" placeholder and wrongly reports
         // it cannot read the image. `.get()` (not get-or-create) avoids
         // allocating a gate for pure-text sessions.
-        if let Some(gate) = self
-            .image_gates
-            .get(&msg.session_key)
-            .map(|g| Arc::clone(g.value()))
-        {
-            drop(gate.lock().await);
+        //
+        // Skip this entirely when *this* event carried its own images: it
+        // already holds `_image_guard` (acquired up-front) and re-locking the
+        // same non-reentrant mutex would self-deadlock, wedging the session for
+        // every later message. Its own images were already awaited synchronously
+        // via `process_images` above, so their descriptions are in history.
+        if msg.attachments.is_empty() {
+            if let Some(gate) = self
+                .image_gates
+                .get(&msg.session_key)
+                .map(|g| Arc::clone(g.value()))
+            {
+                drop(gate.lock().await);
+            }
         }
 
         // Drop blank events — platform sent a message with no text and no attachments.

--- a/crates/garudust-gateway/src/handler_tests.rs
+++ b/crates/garudust-gateway/src/handler_tests.rs
@@ -681,4 +681,35 @@ mod tests {
             .lookup_role("mock", "first_user", None);
         assert!(role.is_none(), "group chat ไม่ควร trigger bootstrap admin");
     }
+
+    /// Regression: a message carrying BOTH text and an image attachment (e.g. a
+    /// LINE reply that quotes an image) must not self-deadlock. The handler
+    /// acquires the per-session image gate up-front, then later awaits the same
+    /// gate to wait for in-flight image analysis. Re-locking the non-reentrant
+    /// mutex from the same task wedged the session forever — the bot went silent.
+    #[tokio::test]
+    async fn text_with_image_attachment_does_not_deadlock() {
+        let tmp = tmpdir();
+        let platform = Arc::new(MockPlatform::new());
+        let mut cfg = make_config(tmp.path());
+        cfg.roles.set_user_role("mock", "alice", "admin");
+        let handler = make_handler(platform.clone(), cfg);
+
+        // A real file so filter_oversized has something to stat.
+        let img = tmp.path().join("pic.jpg");
+        tokio::fs::write(&img, b"\xff\xd8\xff\xe0fake")
+            .await
+            .unwrap();
+
+        let mut msg = dm("alice", "นี่รูปอะไร");
+        msg.attachments = vec![garudust_core::types::ImageAttachment {
+            path: img.to_string_lossy().into_owned(),
+        }];
+
+        // Before the fix this never returned (self-deadlock on the image gate).
+        tokio::time::timeout(std::time::Duration::from_secs(10), handler.handle(msg))
+            .await
+            .expect("handler deadlocked on the image gate")
+            .unwrap();
+    }
 }


### PR DESCRIPTION
## Problem
LINE bot went silent — a whole chat session stopped getting replies.

## Root cause
`GatewayHandler::handle` acquires the per-session image gate up-front (held for the rest of the call) whenever the event has image attachments, then later re-locks the **same** gate to wait for in-flight image analysis. Tokio's `Mutex` is not reentrant, so the second lock from the same task blocks forever and never releases the guard — every subsequent message in that session then blocks on the same gate too.

This never triggered before because a LINE event was always text **XOR** image (image-only events return early via the image-only bypass, before the wait-for-gate). The quoted-reply feature (`500b40e`) introduced the first **text + image** event — a reply quoting an image carries the current text plus the fetched image attachment — landing exactly on the self-lock.

## Fix
Skip the wait-for-gate when this event carries its own images: it already holds the guard and already awaited `process_images` synchronously, so the image descriptions are in history. Re-locking is both unnecessary and the deadlock itself. Text-only events still wait, preserving the original cross-event race fix.

## Verification
- New regression test `text_with_image_attachment_does_not_deadlock` (completes under timeout instead of hanging)
- `cargo fmt --all -- --check` clean
- `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)